### PR TITLE
feat(manifest): v6.2.0 — consumer-side build-manifest Contribution verifier (#25)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -46,6 +46,11 @@ rustflags = ["-C", "link-arg=-Wl,-z,relro,-z,now"]
 # Development settings
 [env]
 RUST_BACKTRACE = "1"
+# ML-DSA-65 (FIPS 204) sign/verify use large stack buffers; in debug builds a
+# single op approaches the 2 MB default test-thread stack, so a test holding a
+# few hybrid identities live across a verify can overflow it. Raise the floor
+# for every thread cargo spawns (libtest + tokio workers). Release is unaffected.
+RUST_MIN_STACK = "8388608"
 
 [profile.dev]
 # Faster incremental builds

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-build-tool"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-crypto"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "aws-lc-rs",
  "criterion",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-keyring"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-manifest-tool"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-verify-core"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "android_system_properties",
  "anyhow",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-verify-ffi"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "aes-gcm",
  "android_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "6.1.1"
+version = "6.2.0"
 edition = "2021"
 rust-version = "1.86"
 license = "AGPL-3.0-or-later"

--- a/bindings/python/ciris_verify/__init__.py
+++ b/bindings/python/ciris_verify/__init__.py
@@ -31,6 +31,7 @@ import logging as _logging
 from .client import CIRISVerify, MockCIRISVerify, verify_tree, DEFAULT_REGISTRY_URL
 from ._jcs import jcs_canonicalize
 from ._federation_identity import create_federation_identity
+from ._manifest_contribution import verify_build_manifest_contribution
 from ._operational_admit import (
     resolve_role_authority,
     verify_delegation_scope_split,
@@ -125,13 +126,14 @@ def get_library_version() -> str:
     return __version__
 
 
-__version__ = "6.1.1"
+__version__ = "6.2.0"
 __all__ = [
     "CIRISVerify",
     "MockCIRISVerify",
     "verify_tree",
     "jcs_canonicalize",
     "create_federation_identity",
+    "verify_build_manifest_contribution",
     "resolve_role_authority",
     "verify_partner_record_quorum",
     "verify_delegation_scope_split",

--- a/bindings/python/ciris_verify/_manifest_contribution.py
+++ b/bindings/python/ciris_verify/_manifest_contribution.py
@@ -1,0 +1,171 @@
+"""Build-manifest Contribution verification — Python binding
+(CIRISVerify#25, v6.2.0+).
+
+Exposes :func:`verify_build_manifest_contribution`, a thin wrapper over the FFI
+symbol ``ciris_verify_build_manifest_contribution`` which calls
+``ciris_verify_core::manifest_contribution`` — the **consumer** of the
+pipeline-as-delegated-attester model.
+
+A CI pipeline holds a ``node`` identity; an accountable human grants it
+``delegates_to(human → pipeline, infra:attest)`` ("publish manifests on my
+behalf"); the pipeline signs each build manifest as that human's delegate. This
+function runs the full authority walk a consumer (CIRISServer's outbox drain,
+registry tooling) must run before trusting a build: pipeline signature → the
+human's delegation grant → the §1.3 infra/agency scope split → the
+"builders I trust" decision. There is one blessed implementation; the wheel
+reaches it rather than reimplementing the chain walk.
+
+**Fail-closed:** a rejection is a successful call returning ``trusted: False``
+with a ``reason``, never an exception. Only a malformed request raises.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import json as _json
+import platform as _platform
+import threading as _threading
+from pathlib import Path
+from typing import Any, Optional
+
+__all__ = ["verify_build_manifest_contribution"]
+
+_lib: Optional[ctypes.CDLL] = None
+_lib_lock = _threading.Lock()
+_SUCCESS = 0
+
+
+def _candidate_paths() -> list[str]:
+    here = Path(__file__).resolve().parent
+    system = _platform.system()
+    names = {
+        "Linux": ["libciris_verify_ffi.so", "libciris_verify.so"],
+        "Darwin": ["libciris_verify_ffi.dylib", "libciris_verify.dylib"],
+        "Windows": ["ciris_verify_ffi.dll", "ciris_verify.dll"],
+    }.get(system, ["libciris_verify_ffi.so"])
+    paths: list[str] = [str(here / n) for n in names]
+    try:
+        from .client import DEFAULT_BINARY_PATHS  # type: ignore
+
+        paths.extend(DEFAULT_BINARY_PATHS.get(system, []))
+    except Exception:  # pragma: no cover - defensive
+        pass
+    return paths
+
+
+def _wire(fn: Any) -> None:
+    fn.argtypes = [
+        ctypes.c_char_p,  # input_json (UTF-8 bytes)
+        ctypes.c_size_t,  # input_len
+        ctypes.POINTER(ctypes.POINTER(ctypes.c_ubyte)),  # result_out
+        ctypes.POINTER(ctypes.c_size_t),  # result_len_out
+    ]
+    fn.restype = ctypes.c_int
+
+
+def _load_lib() -> ctypes.CDLL:
+    global _lib
+    if _lib is not None:
+        return _lib
+    with _lib_lock:
+        if _lib is not None:
+            return _lib
+        last_err: Optional[Exception] = None
+        for path in _candidate_paths():
+            if not Path(path).exists():
+                continue
+            try:
+                lib = ctypes.CDLL(path)
+                _wire(lib.ciris_verify_build_manifest_contribution)
+            except (OSError, AttributeError) as exc:
+                last_err = exc
+                continue
+            lib.ciris_verify_free.argtypes = [ctypes.c_void_p]
+            lib.ciris_verify_free.restype = None
+            _lib = lib
+            return _lib
+    raise RuntimeError(
+        "manifest-contribution FFI symbol not available — could not load the "
+        f"CIRISVerify shared library (last error: {last_err}). The library "
+        "must be built with the wheel (>= v6.2.0)."
+    )
+
+
+def _call(symbol: str, request: dict) -> dict:
+    lib = _load_lib()
+    fn = getattr(lib, symbol)
+    body = _json.dumps(request, ensure_ascii=False).encode("utf-8")
+    out_ptr = ctypes.POINTER(ctypes.c_ubyte)()
+    out_len = ctypes.c_size_t(0)
+    rc = fn(body, len(body), ctypes.byref(out_ptr), ctypes.byref(out_len))
+    if rc != _SUCCESS:
+        raise ValueError(
+            f"{symbol}: malformed request (FFI code {rc}) — this is a caller "
+            "error, distinct from a fail-closed negative verdict"
+        )
+    n = out_len.value
+    if n == 0:
+        return {}
+    try:
+        raw = ctypes.string_at(out_ptr, n)
+    finally:
+        lib.ciris_verify_free(ctypes.cast(out_ptr, ctypes.c_void_p))
+    return _json.loads(raw)
+
+
+def verify_build_manifest_contribution(
+    obj: Any,
+    pipeline_member: dict,
+    grant: dict,
+    granter_member: dict,
+    trusted_build_authorities: Optional[list[str]] = None,
+) -> dict:
+    """Verify a build-manifest Contribution end-to-end (CIRISVerify#25).
+
+    The full chain, all fail-closed: the pipeline's bound-hybrid signature
+    verifies against its pinned pubkeys; the Contribution carries
+    ``delegation_scope: infra:attest`` and a ``dimension`` matching its own
+    ``build.target``; the human's ``delegates_to`` grant verifies against the
+    pinned granter pubkeys, delegates to *this* pipeline, and carries
+    ``infra:attest``; the scope set passes the §1.3 node infra/agency split; and
+    the ``on_behalf_of`` human is in ``trusted_build_authorities``.
+
+    Args:
+        obj: the ``build_manifest_contribution`` object as drained from the CEG
+            outbox (a JSON-able ``SignedCegObject``).
+        pipeline_member: the pipeline ``node``'s pinned pubkeys —
+            ``{"member_id": ..., "ed25519_public_key_base64": ...,
+            "mldsa65_public_key_base64": ...}``. Resolve this from your key
+            directory by the object's ``attesting_key_id`` — never take it from
+            the object (the identity-binding discipline; a forged grant under a
+            human's key_id fails the binding).
+        grant: the ``delegates_to(human → pipeline, infra:attest)`` grant —
+            ``{"signed_envelope": {...}, "ed25519_signature_base64": ...,
+            "mldsa65_signature_base64": ...}``.
+        granter_member: the human granter's pinned pubkeys (same shape as
+            ``pipeline_member``), resolved by the grant's ``attesting_key_id``.
+        trusted_build_authorities: the trio's "builders I trust" set. Pass
+            ``None``/``[]`` to verify the chain *without* the trust decision —
+            useful to surface which human a build roots in before deciding.
+
+    Returns:
+        On trust: ``{"trusted": True, "attested_by": ..., "on_behalf_of": ...,
+        "target": ..., "build_id": ..., "binary_hash": ...,
+        "binary_version": ..., "manifest_hash": ...}``. On rejection:
+        ``{"trusted": False, "reason": "..."}`` naming the first failing step.
+
+    Raises:
+        ValueError: the request itself is malformed (a caller error, NOT a
+            negative verdict).
+        RuntimeError: the shared library / FFI symbols are unavailable.
+    """
+    return _call(
+        "ciris_verify_build_manifest_contribution",
+        {
+            "object": obj,
+            "pipeline_member": pipeline_member,
+            "grant": grant,
+            "granter_member": granter_member,
+            "trusted_build_authorities": trusted_build_authorities or [],
+        },
+    )

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciris-verify"
-version = "6.1.1"
+version = "6.2.0"
 description = "Python bindings for CIRISVerify hardware-rooted license verification"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/src/ciris-verify-core/src/manifest_contribution.rs
+++ b/src/ciris-verify-core/src/manifest_contribution.rs
@@ -38,7 +38,9 @@ use serde_json::{json, Value};
 
 use crate::ceg_outbox::SignedCegObject;
 use crate::error::VerifyError;
-use crate::self_at_login::SelfSigner;
+use crate::operational_admit::verify_delegation_scope_split;
+use crate::self_at_login::{SelfSigner, SignedEnvelope};
+use crate::threshold::{verify_threshold_signatures, ThresholdMember, ThresholdSignature};
 
 /// The `infra:*` scope a pipeline must hold (via `delegates_to`) to publish
 /// manifests on a human's behalf — the existing #77 "attest on my behalf" scope.
@@ -118,11 +120,384 @@ pub async fn sign_build_manifest_contribution(
     ))
 }
 
+// ===========================================================================
+// Consumer side: verify a build-manifest Contribution end-to-end.
+//
+// This is the verify-side primitive CIRISServer (#25) calls when it drains the
+// CEG outbox. Per the #65 two-quorums split, *signature + authority
+// verification is Verify's* — the substrate's merge logic never counts
+// signatures. The server resolves the pinned pubkeys from its key directory and
+// the trusted-author set from the trio's config, then asks this one function
+// "should I trust this build?".
+// ===========================================================================
+
+/// The trust-bearing facts of a build, returned once a Contribution has passed
+/// the full chain. The server stores/relays these — never the unverified body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedManifest {
+    /// The pipeline `node` key_id that signed the Contribution.
+    pub attested_by: String,
+    /// The accountable human the chain roots in (CC §1.13.2).
+    pub on_behalf_of: String,
+    /// Rust target triple.
+    pub target: String,
+    /// The build identifier (Contribution subject).
+    pub build_id: String,
+    /// SHA-256 of the built binary, hex.
+    pub binary_hash: String,
+    /// The binary's version string.
+    pub binary_version: String,
+    /// SHA-256 of the canonical file manifest, hex.
+    pub manifest_hash: String,
+}
+
+/// Why a build-manifest Contribution was **not** trusted. Every variant is a
+/// hard reject — there is no partial-trust path (fail-closed).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ManifestRejection {
+    /// The outbox object is not a `build_manifest_contribution`.
+    WrongKind {
+        /// The kind actually found.
+        kind: String,
+    },
+    /// A required field is missing or the wrong type.
+    Malformed {
+        /// Which field.
+        field: &'static str,
+    },
+    /// The pipeline's bound-hybrid signature did not verify at threshold 1
+    /// against its pinned pubkeys (RequireHybrid — federation tier).
+    PipelineSignatureInvalid,
+    /// The envelope's `attesting_key_id` does not match the supplied pipeline
+    /// member's `member_id` — the caller pinned the wrong key.
+    PipelineKeyMismatch {
+        /// The `attesting_key_id` in the envelope.
+        envelope: String,
+        /// The `member_id` of the pinned member.
+        member: String,
+    },
+    /// The Contribution's `delegation_scope` is not [`MANIFEST_PUBLISH_SCOPE`].
+    WrongScope {
+        /// The scope found.
+        scope: String,
+    },
+    /// The `dimension` is not `provenance:build_manifest:{target}` for the
+    /// attested `build.target` — a mismatched/forged subject.
+    DimensionMismatch {
+        /// The dimension expected from `build.target`.
+        expected: String,
+        /// The dimension found in the envelope.
+        found: String,
+    },
+    /// The granter's (human's) signature over the delegation grant did not
+    /// verify at threshold 1 against the pinned granter pubkeys.
+    GrantSignatureInvalid,
+    /// The grant envelope is not a `dimension: "delegates_to"` capability grant.
+    GrantNotDelegation {
+        /// The dimension found on the grant.
+        dimension: String,
+    },
+    /// The grant's `attesting_key_id` (the granter) does not equal the
+    /// Contribution's `on_behalf_of`, or the pinned granter member — the grant
+    /// does not authorize *this* human.
+    GranterMismatch {
+        /// The grant's `attesting_key_id`.
+        grant: String,
+        /// The Contribution's `on_behalf_of`.
+        on_behalf_of: String,
+    },
+    /// The grant's `subject_key_ids` does not include the pipeline — the human
+    /// delegated to someone else, not this pipeline.
+    GrantSubjectMismatch {
+        /// The pipeline key_id that should have been the subject.
+        pipeline: String,
+    },
+    /// The grant does not actually carry [`MANIFEST_PUBLISH_SCOPE`].
+    GrantMissingScope {
+        /// The scope the Contribution claimed but the grant omits.
+        scope: String,
+    },
+    /// The grant's scope set violates the §1.3 infra/agency split for a `node`
+    /// delegate (e.g. it smuggles an `agency:*` scope).
+    ScopeSplitViolation {
+        /// Human-readable detail from [`verify_delegation_scope_split`].
+        detail: String,
+    },
+    /// The chain is cryptographically sound but the human it roots in is **not**
+    /// in the trio's trusted-build-authority set — "I don't trust this builder."
+    AuthorityNotTrusted {
+        /// The human key_id that was not trusted.
+        on_behalf_of: String,
+    },
+}
+
+impl std::fmt::Display for ManifestRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::WrongKind { kind } => {
+                write!(f, "not a build-manifest contribution: kind {kind:?}")
+            },
+            Self::Malformed { field } => {
+                write!(f, "malformed manifest contribution: field {field:?}")
+            },
+            Self::PipelineSignatureInvalid => {
+                write!(f, "pipeline bound-hybrid signature did not verify")
+            },
+            Self::PipelineKeyMismatch { envelope, member } => {
+                write!(
+                    f,
+                    "pipeline key mismatch: envelope {envelope:?} != pinned member {member:?}"
+                )
+            },
+            Self::WrongScope { scope } => write!(
+                f,
+                "contribution delegation_scope {scope:?} is not infra:attest"
+            ),
+            Self::DimensionMismatch { expected, found } => {
+                write!(
+                    f,
+                    "dimension mismatch: expected {expected:?}, found {found:?}"
+                )
+            },
+            Self::GrantSignatureInvalid => write!(f, "delegation grant signature did not verify"),
+            Self::GrantNotDelegation { dimension } => {
+                write!(f, "grant is not delegates_to: dimension {dimension:?}")
+            },
+            Self::GranterMismatch {
+                grant,
+                on_behalf_of,
+            } => {
+                write!(
+                    f,
+                    "granter mismatch: grant signer {grant:?} != on_behalf_of {on_behalf_of:?}"
+                )
+            },
+            Self::GrantSubjectMismatch { pipeline } => {
+                write!(f, "grant does not delegate to pipeline {pipeline:?}")
+            },
+            Self::GrantMissingScope { scope } => write!(f, "grant does not carry scope {scope:?}"),
+            Self::ScopeSplitViolation { detail } => write!(f, "scope split violation: {detail}"),
+            Self::AuthorityNotTrusted { on_behalf_of } => {
+                write!(
+                    f,
+                    "authority not trusted: {on_behalf_of:?} is not a trusted build authority"
+                )
+            },
+        }
+    }
+}
+
+impl std::error::Error for ManifestRejection {}
+
+/// Pull a `&str` field from a JSON object, or [`ManifestRejection::Malformed`].
+fn str_field<'a>(v: &'a Value, field: &'static str) -> Result<&'a str, ManifestRejection> {
+    v.get(field)
+        .and_then(Value::as_str)
+        .ok_or(ManifestRejection::Malformed { field })
+}
+
+/// Verify a bound-hybrid signature over `envelope` at threshold 1 against a
+/// single pinned `member` (RequireHybrid — the federation-tier default).
+fn envelope_verifies(
+    envelope: &Value,
+    ed_sig: &str,
+    mldsa_sig: Option<&str>,
+    member: &ThresholdMember,
+) -> bool {
+    let Ok(bytes) = crate::jcs::canonicalize(envelope) else {
+        return false;
+    };
+    let sig = ThresholdSignature {
+        member_id: member.member_id.clone(),
+        ed25519_signature_base64: ed_sig.to_string(),
+        mldsa65_signature_base64: mldsa_sig.map(str::to_string),
+    };
+    verify_threshold_signatures(&bytes, std::slice::from_ref(member), &[sig], 1) == Ok(1)
+}
+
+/// Verify a build-manifest Contribution end-to-end and return the trusted build
+/// facts — the **consumer** of [`sign_build_manifest_contribution`].
+///
+/// The full chain (all fail-closed):
+///
+/// 1. `obj` is a `build_manifest_contribution`; its envelope is well-formed.
+/// 2. The **pipeline** bound-hybrid signature verifies at threshold 1 against
+///    `pipeline_member` (the pinned `node` pubkeys), and the envelope's
+///    `attesting_key_id` is that member.
+/// 3. The Contribution carries `delegation_scope == infra:attest` and a
+///    `dimension` matching its own `build.target`.
+/// 4. The **granter** (human) signature over `grant` verifies at threshold 1
+///    against `granter_member`, and `grant` is a `delegates_to` whose signer is
+///    the Contribution's `on_behalf_of`, whose `subject_key_ids` includes the
+///    pipeline, and whose `delegated_scope` carries `infra:attest`.
+/// 5. That scope set passes the §1.3 infra/agency split for a `node` delegate.
+/// 6. `on_behalf_of` is in `trusted_build_authorities` — the trio's "builders I
+///    trust" set. (Pass an empty slice to verify the chain *without* the trust
+///    decision — e.g. to surface "who does this root in?" before deciding.)
+///
+/// `pipeline_member` / `granter_member` are pinned by the **caller** from its
+/// key directory (by `attesting_key_id`) — never taken from the object — so a
+/// forged grant under a human's key_id fails the binding (the #65 / §8.1.12.7.1
+/// identity-binding discipline).
+///
+/// # Errors
+///
+/// A [`ManifestRejection`] naming the first failing step.
+pub fn verify_build_manifest_contribution(
+    obj: &SignedCegObject,
+    pipeline_member: &ThresholdMember,
+    grant: &SignedEnvelope,
+    granter_member: &ThresholdMember,
+    trusted_build_authorities: &[String],
+) -> Result<VerifiedManifest, ManifestRejection> {
+    if obj.kind != BUILD_MANIFEST_CONTRIBUTION_KIND {
+        return Err(ManifestRejection::WrongKind {
+            kind: obj.kind.clone(),
+        });
+    }
+
+    // --- 1. Extract the signed Contribution envelope + its signatures. ---
+    let env = obj
+        .body
+        .get("signed_envelope")
+        .ok_or(ManifestRejection::Malformed {
+            field: "signed_envelope",
+        })?;
+    let ed_sig = str_field(&obj.body, "ed25519_signature_base64")?;
+    let mldsa_sig = obj
+        .body
+        .get("mldsa65_signature_base64")
+        .and_then(Value::as_str);
+
+    // --- 2. Pipeline signature verifies, and binds to the pinned member. ---
+    let attesting_key_id = str_field(env, "attesting_key_id")?;
+    if attesting_key_id != pipeline_member.member_id {
+        return Err(ManifestRejection::PipelineKeyMismatch {
+            envelope: attesting_key_id.to_string(),
+            member: pipeline_member.member_id.clone(),
+        });
+    }
+    if !envelope_verifies(env, ed_sig, mldsa_sig, pipeline_member) {
+        return Err(ManifestRejection::PipelineSignatureInvalid);
+    }
+
+    // --- 3. Scope + dimension self-consistency. ---
+    let scope = str_field(env, "delegation_scope")?;
+    if scope != MANIFEST_PUBLISH_SCOPE {
+        return Err(ManifestRejection::WrongScope {
+            scope: scope.to_string(),
+        });
+    }
+    let build = env
+        .get("build")
+        .ok_or(ManifestRejection::Malformed { field: "build" })?;
+    let target = str_field(build, "target")?;
+    let dimension = str_field(env, "dimension")?;
+    let expected_dim = build_manifest_dimension(target);
+    if dimension != expected_dim {
+        return Err(ManifestRejection::DimensionMismatch {
+            expected: expected_dim,
+            found: dimension.to_string(),
+        });
+    }
+    let on_behalf_of = str_field(env, "on_behalf_of")?;
+
+    // --- 4. The delegation grant: human → pipeline, signature-valid. ---
+    let grant_env = &grant.signed_envelope;
+    let grant_dimension = str_field(grant_env, "dimension")?;
+    if grant_dimension != "delegates_to" {
+        return Err(ManifestRejection::GrantNotDelegation {
+            dimension: grant_dimension.to_string(),
+        });
+    }
+    let grant_signer = str_field(grant_env, "attesting_key_id")?;
+    // The grant must be signed by the human the Contribution claims, *and* that
+    // human must be the pinned granter member (binding to the directory, not to
+    // the self-asserted field).
+    if grant_signer != on_behalf_of || grant_signer != granter_member.member_id {
+        return Err(ManifestRejection::GranterMismatch {
+            grant: grant_signer.to_string(),
+            on_behalf_of: on_behalf_of.to_string(),
+        });
+    }
+    let mldsa_grant = if grant.mldsa65_signature_base64.is_empty() {
+        None
+    } else {
+        Some(grant.mldsa65_signature_base64.as_str())
+    };
+    if !envelope_verifies(
+        grant_env,
+        &grant.ed25519_signature_base64,
+        mldsa_grant,
+        granter_member,
+    ) {
+        return Err(ManifestRejection::GrantSignatureInvalid);
+    }
+
+    // The grant must delegate to *this* pipeline.
+    let subjects = grant_env
+        .get("subject_key_ids")
+        .and_then(Value::as_array)
+        .ok_or(ManifestRejection::Malformed {
+            field: "subject_key_ids",
+        })?;
+    if !subjects
+        .iter()
+        .any(|s| s.as_str() == Some(attesting_key_id))
+    {
+        return Err(ManifestRejection::GrantSubjectMismatch {
+            pipeline: attesting_key_id.to_string(),
+        });
+    }
+
+    // The grant must actually carry the manifest-publish scope.
+    let grant_scopes: Vec<String> = grant_env
+        .get("delegated_scope")
+        .and_then(Value::as_array)
+        .ok_or(ManifestRejection::Malformed {
+            field: "delegated_scope",
+        })?
+        .iter()
+        .filter_map(|s| s.as_str().map(str::to_string))
+        .collect();
+    if !grant_scopes.iter().any(|s| s == MANIFEST_PUBLISH_SCOPE) {
+        return Err(ManifestRejection::GrantMissingScope {
+            scope: MANIFEST_PUBLISH_SCOPE.to_string(),
+        });
+    }
+
+    // --- 5. §1.3 infra/agency split: a `node` pipeline may hold only infra:*. ---
+    if let Err(e) = verify_delegation_scope_split("node", &grant_scopes) {
+        return Err(ManifestRejection::ScopeSplitViolation {
+            detail: e.to_string(),
+        });
+    }
+
+    // --- 6. The trust decision: is the root human a trusted build authority? ---
+    if !trusted_build_authorities.is_empty()
+        && !trusted_build_authorities.iter().any(|a| a == on_behalf_of)
+    {
+        return Err(ManifestRejection::AuthorityNotTrusted {
+            on_behalf_of: on_behalf_of.to_string(),
+        });
+    }
+
+    Ok(VerifiedManifest {
+        attested_by: attesting_key_id.to_string(),
+        on_behalf_of: on_behalf_of.to_string(),
+        target: target.to_string(),
+        build_id: str_field(build, "build_id")?.to_string(),
+        binary_hash: str_field(build, "binary_hash")?.to_string(),
+        binary_version: str_field(build, "binary_version")?.to_string(),
+        manifest_hash: str_field(build, "manifest_hash")?.to_string(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::jcs;
-    use crate::self_at_login::HybridSigningIdentity;
+    use crate::self_at_login::{sign_delegation_grant, HybridSigningIdentity};
     use crate::threshold::{verify_threshold_signatures, ThresholdSignature};
 
     fn build_owned() -> (String, String) {
@@ -212,6 +587,194 @@ mod tests {
             verify_threshold_signatures(&bytes, &[pipeline.directory_member().unwrap()], &[sig], 1)
                 .is_err(),
             "a tampered build_hash must break the manifest signature"
+        );
+    }
+
+    // -- Consumer side: verify_build_manifest_contribution --------------------
+
+    const HUMAN: &str = "eric-moore-6qg6wdx2dq";
+    const PIPELINE: &str = "ciris-verify-build-pipeline";
+    const TS: &str = "2026-06-18T00:00:00Z";
+
+    /// Build a full valid chain: a human grants `infra:attest` to a pipeline
+    /// `node`, the pipeline signs a manifest Contribution on the human's behalf.
+    /// Returns everything `verify_build_manifest_contribution` needs.
+    async fn valid_chain() -> (
+        SignedCegObject,
+        ThresholdMember,
+        SignedEnvelope,
+        ThresholdMember,
+    ) {
+        let human = HybridSigningIdentity::generate(HUMAN).unwrap();
+        let pipeline = HybridSigningIdentity::generate(PIPELINE).unwrap();
+        let grant =
+            sign_delegation_grant(&human, PIPELINE, &["infra:attest".to_string()], TS).unwrap();
+        let (bh, mh) = build_owned();
+        let b = BuildAttestation {
+            target: "x86_64-unknown-linux-gnu",
+            binary_hash: &bh,
+            build_id: "ciris-verify@6.2.0",
+            binary_version: "6.2.0",
+            manifest_hash: &mh,
+        };
+        let obj = sign_build_manifest_contribution(
+            &pipeline,
+            &b,
+            HUMAN,
+            "delegation:infra-attest:abc123",
+            TS,
+        )
+        .await
+        .unwrap();
+        (
+            obj,
+            pipeline.directory_member().unwrap(),
+            grant,
+            human.directory_member().unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn valid_chain_verifies_and_roots_in_the_trusted_human() {
+        let (obj, pm, grant, gm) = valid_chain().await;
+        let v = verify_build_manifest_contribution(&obj, &pm, &grant, &gm, &[HUMAN.to_string()])
+            .expect("a fully valid chain rooting in a trusted human must verify");
+        assert_eq!(v.attested_by, PIPELINE);
+        assert_eq!(v.on_behalf_of, HUMAN);
+        assert_eq!(v.target, "x86_64-unknown-linux-gnu");
+        assert_eq!(v.binary_version, "6.2.0");
+    }
+
+    #[tokio::test]
+    async fn empty_trust_set_verifies_chain_without_trust_decision() {
+        // Chain-valid but no trust list supplied → "who does this root in?" path.
+        let (obj, pm, grant, gm) = valid_chain().await;
+        let v = verify_build_manifest_contribution(&obj, &pm, &grant, &gm, &[]).unwrap();
+        assert_eq!(v.on_behalf_of, HUMAN);
+    }
+
+    #[tokio::test]
+    async fn untrusted_human_is_rejected_even_with_a_valid_chain() {
+        let (obj, pm, grant, gm) = valid_chain().await;
+        let err = verify_build_manifest_contribution(
+            &obj,
+            &pm,
+            &grant,
+            &gm,
+            &["someone-else-zzz".to_string()],
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            ManifestRejection::AuthorityNotTrusted {
+                on_behalf_of: HUMAN.to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn tampered_contribution_fails_the_pipeline_signature() {
+        let (mut obj, pm, grant, gm) = valid_chain().await;
+        obj.body["signed_envelope"]["build"]["binary_hash"] = json!("00".repeat(32));
+        let err = verify_build_manifest_contribution(&obj, &pm, &grant, &gm, &[HUMAN.to_string()])
+            .unwrap_err();
+        assert_eq!(err, ManifestRejection::PipelineSignatureInvalid);
+    }
+
+    #[tokio::test]
+    async fn wrong_pinned_pipeline_key_is_rejected_before_sig_check() {
+        let (obj, _pm, grant, gm) = valid_chain().await;
+        let wrong = HybridSigningIdentity::generate("not-the-pipeline")
+            .unwrap()
+            .directory_member()
+            .unwrap();
+        let err =
+            verify_build_manifest_contribution(&obj, &wrong, &grant, &gm, &[HUMAN.to_string()])
+                .unwrap_err();
+        assert!(matches!(err, ManifestRejection::PipelineKeyMismatch { .. }));
+    }
+
+    #[tokio::test]
+    async fn forged_grant_under_the_humans_key_id_fails_the_binding() {
+        // An attacker mints a grant claiming the human's key_id but signs it with
+        // their own key. The pinned granter member is the REAL human → sig fails.
+        let (obj, pm, _grant, gm) = valid_chain().await;
+        let attacker = HybridSigningIdentity::generate(HUMAN).unwrap(); // same id, different keys
+        let forged =
+            sign_delegation_grant(&attacker, PIPELINE, &["infra:attest".to_string()], TS).unwrap();
+        let err = verify_build_manifest_contribution(&obj, &pm, &forged, &gm, &[HUMAN.to_string()])
+            .unwrap_err();
+        assert_eq!(err, ManifestRejection::GrantSignatureInvalid);
+    }
+
+    #[tokio::test]
+    async fn grant_to_a_different_pipeline_is_rejected() {
+        let (obj, pm, _grant, _gm) = valid_chain().await;
+        // The human really did sign a grant — but to some other node. Rebuild a
+        // fresh granter member so its keys match this new grant.
+        let human = HybridSigningIdentity::generate(HUMAN).unwrap();
+        let gm2 = human.directory_member().unwrap();
+        let grant =
+            sign_delegation_grant(&human, "some-other-node", &["infra:attest".to_string()], TS)
+                .unwrap();
+        let err = verify_build_manifest_contribution(&obj, &pm, &grant, &gm2, &[HUMAN.to_string()])
+            .unwrap_err();
+        assert_eq!(
+            err,
+            ManifestRejection::GrantSubjectMismatch {
+                pipeline: PIPELINE.to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn grant_missing_infra_attest_scope_is_rejected() {
+        let (obj, pm, _grant, _gm) = valid_chain().await;
+        let human = HybridSigningIdentity::generate(HUMAN).unwrap();
+        let gm2 = human.directory_member().unwrap();
+        // A grant that delegates SOME infra scope, but not infra:attest.
+        let grant =
+            sign_delegation_grant(&human, PIPELINE, &["infra:relay".to_string()], TS).unwrap();
+        let err = verify_build_manifest_contribution(&obj, &pm, &grant, &gm2, &[HUMAN.to_string()])
+            .unwrap_err();
+        assert_eq!(
+            err,
+            ManifestRejection::GrantMissingScope {
+                scope: "infra:attest".to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn node_grant_smuggling_agency_scope_fails_the_split() {
+        let (obj, pm, _grant, _gm) = valid_chain().await;
+        let human = HybridSigningIdentity::generate(HUMAN).unwrap();
+        let gm2 = human.directory_member().unwrap();
+        // Carries infra:attest (so the scope check passes) but also an agency
+        // scope a node must never hold → §1.3 split rejects it.
+        let grant = sign_delegation_grant(
+            &human,
+            PIPELINE,
+            &["infra:attest".to_string(), "agency:act".to_string()],
+            TS,
+        )
+        .unwrap();
+        let err = verify_build_manifest_contribution(&obj, &pm, &grant, &gm2, &[HUMAN.to_string()])
+            .unwrap_err();
+        assert!(matches!(err, ManifestRejection::ScopeSplitViolation { .. }));
+    }
+
+    #[tokio::test]
+    async fn wrong_kind_object_is_rejected() {
+        let (mut obj, pm, grant, gm) = valid_chain().await;
+        obj.kind = "something_else".to_string();
+        let err = verify_build_manifest_contribution(&obj, &pm, &grant, &gm, &[HUMAN.to_string()])
+            .unwrap_err();
+        assert_eq!(
+            err,
+            ManifestRejection::WrongKind {
+                kind: "something_else".to_string()
+            }
         );
     }
 }

--- a/src/ciris-verify-ffi/src/lib.rs
+++ b/src/ciris-verify-ffi/src/lib.rs
@@ -60,6 +60,7 @@ mod wheel_hybrid_kex;
 mod wheel_jcs;
 mod wheel_key_grant;
 mod wheel_locale_merkle;
+mod wheel_manifest_contribution;
 mod wheel_operational_admit;
 mod wheel_reconsider_dos;
 mod wheel_skill_import;

--- a/src/ciris-verify-ffi/src/wheel_manifest_contribution.rs
+++ b/src/ciris-verify-ffi/src/wheel_manifest_contribution.rs
@@ -1,0 +1,302 @@
+//! Build-manifest Contribution verification FFI surface for the Python wheel
+//! (CIRISVerify#25, v6.2.0+).
+//!
+//! Wraps [`ciris_verify_core::manifest_contribution::verify_build_manifest_contribution`]
+//! — the **consumer** of the pipeline-as-delegated-attester model — so a wheel
+//! consumer (CIRISServer's outbox drain, registry tooling) runs the *exact same*
+//! authority walk the Rust verifier runs: pipeline signature → human's
+//! delegation grant → §1.3 scope split → trusted-build-authority decision. No
+//! reimplemented chain walk, no bespoke `/v1/builds` trust path.
+//!
+//! ## Wire shape
+//!
+//! Takes the UTF-8 bytes of a JSON request object and returns the UTF-8 bytes of
+//! a JSON verdict (NUL-free, NOT NUL-terminated; the caller has the length). A
+//! *rejection* is a successful call returning `{ "trusted": false, "reason":
+//! "..." }` — only malformed input yields a `SerializationError` code. This
+//! keeps the fail-closed contract: the caller reads the verdict, and the absence
+//! of `trusted: true` is rejection.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use ciris_verify_core::ceg_outbox::SignedCegObject;
+use ciris_verify_core::manifest_contribution::verify_build_manifest_contribution;
+use ciris_verify_core::self_at_login::SignedEnvelope;
+use ciris_verify_core::threshold::ThresholdMember;
+use serde::{Deserialize, Serialize};
+
+use crate::CirisVerifyError;
+
+macro_rules! ffi_guard {
+    ($fn_name:expr, $body:expr) => {{
+        let result = catch_unwind(AssertUnwindSafe(|| $body));
+        match result {
+            Ok(code) => code,
+            Err(e) => {
+                let msg = if let Some(s) = e.downcast_ref::<&str>() {
+                    (*s).to_string()
+                } else if let Some(s) = e.downcast_ref::<String>() {
+                    s.clone()
+                } else {
+                    "unknown panic".to_string()
+                };
+                tracing::error!("PANIC in {}: {}", $fn_name, msg);
+                CirisVerifyError::InternalError as i32
+            },
+        }
+    }};
+}
+
+/// Allocate a raw-bytes output buffer on the C heap (caller frees via
+/// `ciris_verify_free`). Mirrors `wheel_operational_admit::emit_bytes`.
+unsafe fn emit_bytes(bytes: &[u8], result_out: *mut *mut u8, result_len_out: *mut usize) -> i32 {
+    let len = bytes.len();
+    if len == 0 {
+        *result_out = std::ptr::NonNull::dangling().as_ptr();
+        *result_len_out = 0;
+        return CirisVerifyError::Success as i32;
+    }
+    let ptr = libc::malloc(len) as *mut u8;
+    if ptr.is_null() {
+        return CirisVerifyError::InternalError as i32;
+    }
+    std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, len);
+    *result_out = ptr;
+    *result_len_out = len;
+    CirisVerifyError::Success as i32
+}
+
+#[derive(Deserialize)]
+struct ManifestRequest {
+    /// The `build_manifest_contribution` object as drained from the outbox.
+    object: SignedCegObject,
+    /// Pinned pubkeys of the pipeline `node` (resolved by the caller from its
+    /// key directory by `attesting_key_id` — never taken from the object).
+    pipeline_member: ThresholdMember,
+    /// The `delegates_to(human → pipeline, infra:attest)` grant.
+    grant: SignedEnvelope,
+    /// Pinned pubkeys of the human granter (resolved by the caller by the
+    /// grant's `attesting_key_id`).
+    granter_member: ThresholdMember,
+    /// The trio's "builders I trust" set. Empty → verify the chain *without* the
+    /// trust decision (surfaces who it roots in).
+    #[serde(default)]
+    trusted_build_authorities: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct ManifestVerdict {
+    /// Whether the full chain verified *and* rooted in a trusted human.
+    trusted: bool,
+    /// The pipeline key_id that signed (present on success).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    attested_by: Option<String>,
+    /// The accountable human the chain roots in (present on success).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    on_behalf_of: Option<String>,
+    /// Rust target triple (present on success).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<String>,
+    /// The build identifier (present on success).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    build_id: Option<String>,
+    /// SHA-256 of the built binary, hex (present on success).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    binary_hash: Option<String>,
+    /// The binary's version string (present on success).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    binary_version: Option<String>,
+    /// SHA-256 of the canonical file manifest, hex (present on success).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    manifest_hash: Option<String>,
+    /// The first failing step (present on rejection).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+}
+
+/// Verify a build-manifest Contribution end-to-end (CIRISVerify#25).
+///
+/// `input_json` is a JSON object:
+/// ```json
+/// {
+///   "object": { ...the build_manifest_contribution SignedCegObject... },
+///   "pipeline_member": { "member_id": "...", "ed25519_public_key_base64": "...",
+///                        "mldsa65_public_key_base64": "..." },
+///   "grant": { "signed_envelope": {...}, "ed25519_signature_base64": "...",
+///              "mldsa65_signature_base64": "..." },
+///   "granter_member": { "member_id": "...", "ed25519_public_key_base64": "...",
+///                       "mldsa65_public_key_base64": "..." },
+///   "trusted_build_authorities": ["human-key-id", ...]
+/// }
+/// ```
+/// On success `result_out` receives the verified build facts
+/// (`{ "trusted": true, "attested_by": ..., "on_behalf_of": ..., "target": ...,
+/// "build_id": ..., "binary_hash": ..., "binary_version": ...,
+/// "manifest_hash": ... }`); on rejection `{ "trusted": false, "reason": "..." }`.
+/// Returns `Success` (0), `InvalidArgument` on a null pointer, or
+/// `SerializationError` on malformed input.
+///
+/// # Safety
+/// `input_json` must point to `input_len` valid bytes; `result_out` and
+/// `result_len_out` must be valid pointers.
+#[no_mangle]
+pub unsafe extern "C" fn ciris_verify_build_manifest_contribution(
+    input_json: *const u8,
+    input_len: usize,
+    result_out: *mut *mut u8,
+    result_len_out: *mut usize,
+) -> i32 {
+    ffi_guard!("ciris_verify_build_manifest_contribution", {
+        if input_json.is_null() || result_out.is_null() || result_len_out.is_null() {
+            return CirisVerifyError::InvalidArgument as i32;
+        }
+        let input = std::slice::from_raw_parts(input_json, input_len);
+        let req: ManifestRequest = match serde_json::from_slice(input) {
+            Ok(v) => v,
+            Err(_) => return CirisVerifyError::SerializationError as i32,
+        };
+        let verdict = match verify_build_manifest_contribution(
+            &req.object,
+            &req.pipeline_member,
+            &req.grant,
+            &req.granter_member,
+            &req.trusted_build_authorities,
+        ) {
+            Ok(v) => ManifestVerdict {
+                trusted: true,
+                attested_by: Some(v.attested_by),
+                on_behalf_of: Some(v.on_behalf_of),
+                target: Some(v.target),
+                build_id: Some(v.build_id),
+                binary_hash: Some(v.binary_hash),
+                binary_version: Some(v.binary_version),
+                manifest_hash: Some(v.manifest_hash),
+                reason: None,
+            },
+            Err(e) => ManifestVerdict {
+                trusted: false,
+                attested_by: None,
+                on_behalf_of: None,
+                target: None,
+                build_id: None,
+                binary_hash: None,
+                binary_version: None,
+                manifest_hash: None,
+                reason: Some(e.to_string()),
+            },
+        };
+        match serde_json::to_vec(&verdict) {
+            Ok(bytes) => emit_bytes(&bytes, result_out, result_len_out),
+            Err(_) => CirisVerifyError::SerializationError as i32,
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ciris_verify_core::manifest_contribution::{
+        sign_build_manifest_contribution, BuildAttestation,
+    };
+    use ciris_verify_core::self_at_login::{sign_delegation_grant, HybridSigningIdentity};
+    use serde_json::json;
+
+    const HUMAN: &str = "eric-moore-6qg6wdx2dq";
+    const PIPELINE: &str = "ciris-verify-build-pipeline";
+    const TS: &str = "2026-06-18T00:00:00Z";
+
+    async fn valid_request() -> serde_json::Value {
+        let human = HybridSigningIdentity::generate(HUMAN).unwrap();
+        let pipeline = HybridSigningIdentity::generate(PIPELINE).unwrap();
+        let grant =
+            sign_delegation_grant(&human, PIPELINE, &["infra:attest".to_string()], TS).unwrap();
+        let bh = "ab".repeat(32);
+        let mh = "cd".repeat(32);
+        let b = BuildAttestation {
+            target: "x86_64-unknown-linux-gnu",
+            binary_hash: &bh,
+            build_id: "ciris-verify@6.2.0",
+            binary_version: "6.2.0",
+            manifest_hash: &mh,
+        };
+        let obj = sign_build_manifest_contribution(
+            &pipeline,
+            &b,
+            HUMAN,
+            "delegation:infra-attest:abc123",
+            TS,
+        )
+        .await
+        .unwrap();
+        json!({
+            "object": obj,
+            "pipeline_member": pipeline.directory_member().unwrap(),
+            "grant": grant,
+            "granter_member": human.directory_member().unwrap(),
+            "trusted_build_authorities": [HUMAN],
+        })
+    }
+
+    unsafe fn call(req: &serde_json::Value) -> Result<serde_json::Value, i32> {
+        let body = serde_json::to_vec(req).unwrap();
+        let mut out: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = ciris_verify_build_manifest_contribution(
+            body.as_ptr(),
+            body.len(),
+            &mut out,
+            &mut out_len,
+        );
+        if rc != CirisVerifyError::Success as i32 {
+            return Err(rc);
+        }
+        let bytes = std::slice::from_raw_parts(out, out_len).to_vec();
+        if out_len != 0 {
+            libc::free(out as *mut libc::c_void);
+        }
+        Ok(serde_json::from_slice(&bytes).unwrap())
+    }
+
+    #[tokio::test]
+    async fn valid_chain_trusted_via_ffi() {
+        let req = valid_request().await;
+        let v = unsafe { call(&req) }.unwrap();
+        assert_eq!(v["trusted"], json!(true));
+        assert_eq!(v["on_behalf_of"], json!(HUMAN));
+        assert_eq!(v["attested_by"], json!(PIPELINE));
+        assert_eq!(v["binary_version"], json!("6.2.0"));
+    }
+
+    #[tokio::test]
+    async fn untrusted_human_rejected_via_ffi() {
+        let mut req = valid_request().await;
+        req["trusted_build_authorities"] = json!(["someone-else"]);
+        let v = unsafe { call(&req) }.unwrap();
+        assert_eq!(v["trusted"], json!(false));
+        assert!(v["reason"].as_str().unwrap().contains("not trusted"));
+    }
+
+    #[tokio::test]
+    async fn tampered_object_rejected_via_ffi() {
+        let mut req = valid_request().await;
+        req["object"]["body"]["signed_envelope"]["build"]["binary_hash"] = json!("00".repeat(32));
+        let v = unsafe { call(&req) }.unwrap();
+        assert_eq!(v["trusted"], json!(false));
+    }
+
+    #[test]
+    fn malformed_input_is_serialization_error() {
+        let mut out: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        let bad = b"{not json";
+        let rc = unsafe {
+            ciris_verify_build_manifest_contribution(
+                bad.as_ptr(),
+                bad.len(),
+                &mut out,
+                &mut out_len,
+            )
+        };
+        assert_eq!(rc, CirisVerifyError::SerializationError as i32);
+    }
+}


### PR DESCRIPTION
## What

The **consumer side** of the v6.1.0 pipeline-as-delegated-attester producer — the verify-side primitive **CIRISServer (#25)** calls when it drains the CEG outbox. Per the #65 two-quorums split, *signature + authority verification is Verify's*; the server stays thin glue: it pins keys from its directory + the trusted-author set from the trio's config, then asks one function **"should I trust this build?"**

## The chain — `verify_build_manifest_contribution`

All steps fail-closed; the returned `ManifestRejection` names the first to fail:

1. object is a `build_manifest_contribution`; envelope well-formed
2. pipeline bound-hybrid signature verifies at **threshold-1, RequireHybrid** against the **caller-pinned** `node` pubkeys, bound to the envelope's `attesting_key_id`
3. `delegation_scope == infra:attest`; `dimension` matches its own `build.target`
4. the human's `delegates_to` grant verifies against the pinned **granter** pubkeys, delegates to **this** pipeline, and carries `infra:attest`
5. §1.3 `node` infra/agency scope split holds (no smuggled `agency:*`)
6. `on_behalf_of` ∈ the trio's `trusted_build_authorities` (pass `[]` to verify the chain *without* the trust decision — surfaces who a build roots in)

Keys are pinned by the **caller**, never taken from the object → a forged grant under a human's key_id fails the binding (#65 / §8.1.12.7.1 identity-binding discipline).

## Surface (easy to consume)

- **Rust** — `verify_build_manifest_contribution` → `VerifiedManifest` | `ManifestRejection` (12 reasons). CIRISServer links the crate directly.
- **FFI** — `ciris_verify_build_manifest_contribution` (JSON-in/JSON-out, mirrors `wheel_operational_admit`)
- **Python** — `verify_build_manifest_contribution`

## Notes

- `.cargo/config.toml`: `RUST_MIN_STACK=8 MiB` — ML-DSA-65 debug sign/verify approaches the 2 MiB test-thread stack; a test holding a few hybrid identities live across a verify overflowed it. Raises the floor repo-wide (release unaffected).
- **Cross-impl flag:** the request/verdict wire shapes are pinned here, flagged for CIRISServer/Registry cross-confirmation (like the #76 set).

## Tests

16 new (12 core + 4 FFI): valid chain → trusted, untrusted human, tampered object, wrong pinned key, forged grant under the human's key_id, grant to a different pipeline, missing `infra:attest`, smuggled `agency:*`, wrong kind. **691 core + 63 FFI lib tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)