### PR TITLE
fix(identity): v6.6.1 — decouple ML-DSA seal alias from recorded key_id (#89)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-build-tool"
-version = "6.6.0"
+version = "6.6.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-crypto"
-version = "6.6.0"
+version = "6.6.1"
 dependencies = [
  "aws-lc-rs",
  "chacha20poly1305",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-keyring"
-version = "6.6.0"
+version = "6.6.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-manifest-tool"
-version = "6.6.0"
+version = "6.6.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-verify-core"
-version = "6.6.0"
+version = "6.6.1"
 dependencies = [
  "android_system_properties",
  "anyhow",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-verify-ffi"
-version = "6.6.0"
+version = "6.6.1"
 dependencies = [
  "aes-gcm",
  "android_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "6.6.0"
+version = "6.6.1"
 edition = "2021"
 rust-version = "1.86"
 license = "AGPL-3.0-or-later"

--- a/bindings/python/ciris_verify/__init__.py
+++ b/bindings/python/ciris_verify/__init__.py
@@ -126,7 +126,7 @@ def get_library_version() -> str:
     return __version__
 
 
-__version__ = "6.6.0"
+__version__ = "6.6.1"
 __all__ = [
     "CIRISVerify",
     "MockCIRISVerify",

--- a/bindings/python/ciris_verify/_federation_identity.py
+++ b/bindings/python/ciris_verify/_federation_identity.py
@@ -91,6 +91,11 @@ def create_federation_identity(config: dict[str, Any]) -> dict[str, Any]:
             ``seed_dir`` (str, REQUIRED — where the sealed Ed25519 + ML-DSA seeds live),
             ``identity_type`` (``"user"`` | ``"agent"``; default ``"user"``),
             ``fed_key_id`` (str | None; default ``sha256(ed_pubkey)`` hex),
+            ``label`` (str | None; for the ``label-fingerprint`` derived key_id),
+            ``seal_alias`` (str | None; CIRISVerify#89 — key the ML-DSA seal under a
+                stable keystore alias while recording under the derived ``key_id``,
+                so a switch to derived key_ids needs no custody re-open. Omit for
+                back-compat: the seal is keyed by ``key_id``),
             ``valid_from`` (RFC-3339 str; default host-now),
             ``write_outbox`` (bool; default ``True``).
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciris-verify"
-version = "6.6.0"
+version = "6.6.1"
 description = "Python bindings for CIRISVerify hardware-rooted license verification"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/src/ciris-verify-core/src/bin/ciris_verify.rs
+++ b/src/ciris-verify-core/src/bin/ciris_verify.rs
@@ -2159,6 +2159,7 @@ async fn run_identity_create(args: IdentityCreateArgs, json_output: bool) {
         args.fed_key_id.clone(),
         args.label.as_deref(),
         &now,
+        None, // CLI: seal under key_id (back-compat); the Server USER path uses seal_alias
     )
     .await
     {

--- a/src/ciris-verify-core/src/federation_identity.rs
+++ b/src/ciris-verify-core/src/federation_identity.rs
@@ -63,6 +63,17 @@ pub struct CreatedIdentity {
 /// `label` is given; else `derive_key_id("id", …)`. The returned
 /// [`CreatedIdentity::code`] is the shareable fedcode for `identity_type`.
 ///
+/// `seal_alias` keys the **ML-DSA-65 seal storage** independently of the
+/// recorded/encoded `key_id` (CIRISVerify#89). Pass `None` for the back-compat
+/// default — the seal is keyed by `key_id`, exactly as before. Pass `Some(alias)`
+/// to record under the derived `key_id` while sealing (and re-opening) the PQC
+/// half under a **stable keystore alias** — so a switch to derived key_ids needs
+/// no custody re-open / lockout for already-sealed seeds. The ML-DSA *pubkey* is
+/// a function of the sealed *seed* (under `seal_alias`), not the alias string,
+/// so the recorded record stays self-consistent and re-open by `seal_alias`
+/// reproduces it. (CIRISServer's USER path: record under
+/// `derive_key_id("<alias>-user", ed_pub)`, seal under the stable `<alias>-user`.)
+///
 /// # Errors
 ///
 /// [`VerifyError`] if the signer is not Ed25519, the pubkey/seed cannot be
@@ -73,6 +84,7 @@ pub async fn create_federation_identity(
     fed_key_id: Option<String>,
     label: Option<&str>,
     valid_from: &str,
+    seal_alias: Option<&str>,
 ) -> Result<CreatedIdentity, VerifyError> {
     let ed_pub = hw_signer.public_key().await.map_err(keyring_err)?;
     let key_id =
@@ -83,7 +95,12 @@ pub async fn create_federation_identity(
     // Secure Enclave / StrongBox on mobile; software-sealed AES-GCM fallback
     // otherwise — never a plaintext file) and unsealed only transiently to
     // sign. Auto-generates + seals on first call, adopts the sealed seed after.
-    let mldsa = ciris_keyring::get_platform_sealed_mldsa65_signer(&key_id, keys_dir())
+    //
+    // #89: the seal is keyed by `seal_alias` when given (a stable keystore
+    // alias), else by the recorded `key_id` (back-compat). Decoupling lets the
+    // recorded key_id move to the derived form without re-sealing every seed.
+    let seal_id = seal_alias.unwrap_or(&key_id);
+    let mldsa = ciris_keyring::get_platform_sealed_mldsa65_signer(seal_id, keys_dir())
         .map_err(keyring_err)?;
 
     let identity = HardwareRootedIdentity::new(key_id.clone(), hw_signer, Arc::from(mldsa))?;
@@ -150,6 +167,7 @@ mod tests {
             None,
             Some("Eric Moore"),
             "2026-06-18T00:00:00Z",
+            None,
         )
         .await
         .unwrap();
@@ -174,6 +192,55 @@ mod tests {
         assert_eq!(rec["identity_type"], "user");
         assert_eq!(rec["algorithm"], "hybrid");
         assert!(created.object.signatures.is_none());
+
+        std::env::remove_var(crate::ceg_outbox::CIRIS_HOME_ENV);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn seal_alias_decouples_recorded_key_id_from_seal_storage() {
+        // #89: record under the derived key_id, seal the ML-DSA half under a
+        // stable keystore alias — and re-opening the seal by that alias must
+        // reproduce the recorded ML-DSA pubkey (no custody migration).
+        let _g = crate::ceg_outbox::CIRIS_HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let dir = tmp("seal-alias");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::env::set_var(crate::ceg_outbox::CIRIS_HOME_ENV, &dir);
+
+        let hw: Arc<dyn HardwareSigner> =
+            Arc::new(ciris_keyring::Ed25519SoftwareSigner::from_bytes(&[5u8; 32], "fed").unwrap());
+        let recorded = "eric-moore-derivedfp00".to_string();
+        let seal_alias = "stable-keystore-alias-user";
+        let created = create_federation_identity(
+            hw,
+            "user",
+            Some(recorded.clone()),
+            Some("Eric Moore"),
+            "2026-06-18T00:00:00Z",
+            Some(seal_alias),
+        )
+        .await
+        .unwrap();
+
+        // Recorded/encoded under the derived key_id, NOT the seal alias.
+        assert_eq!(created.key_id, recorded);
+        assert_eq!(created.object.key_id, recorded);
+        assert_eq!(created.object.body["record"]["key_id"], recorded);
+        assert_ne!(created.key_id, seal_alias);
+
+        // The recorded ML-DSA pubkey == the seed sealed under `seal_alias`, so a
+        // re-open by the alias (resolve_user_signer) reproduces it — no lockout.
+        let recorded_mldsa_pub = created.object.body["record"]["pubkey_ml_dsa_65_base64"]
+            .as_str()
+            .unwrap();
+        let reopened =
+            ciris_keyring::get_platform_sealed_mldsa65_signer(seal_alias, keys_dir()).unwrap();
+        let reopened_pub =
+            base64::engine::general_purpose::STANDARD.encode(reopened.public_key().await.unwrap());
+        assert_eq!(recorded_mldsa_pub, reopened_pub);
 
         std::env::remove_var(crate::ceg_outbox::CIRIS_HOME_ENV);
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/ciris-verify-ffi/src/lib.rs
+++ b/src/ciris-verify-ffi/src/lib.rs
@@ -1740,6 +1740,12 @@ pub unsafe extern "C" fn ciris_verify_create_federation_identity(
             .get("label")
             .and_then(|v| v.as_str())
             .map(str::to_string);
+        // #89: optional — key the ML-DSA seal under a stable alias while the
+        // recorded key_id is the derived form. Omit for back-compat (seal == key_id).
+        let seal_alias = cfg
+            .get("seal_alias")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
         let valid_from = cfg
             .get("valid_from")
             .and_then(|v| v.as_str())
@@ -1767,6 +1773,7 @@ pub unsafe extern "C" fn ciris_verify_create_federation_identity(
                 fed_key_id,
                 label.as_deref(),
                 &valid_from,
+                seal_alias.as_deref(),
             )
             .await
             .map_err(|e| format!("create identity: {e}"))?;


### PR DESCRIPTION
## What (closes #89)

`create_federation_identity` keyed the **ML-DSA-65 seal storage** by the same id it **recorded/encoded**, so moving to derived key_ids (the #247 USER-path fix) would have re-keyed every seal and **locked out already-sealed identities** on re-open.

New `seal_alias: Option<&str>` (last arg):
- `None` → back-compat (seal keyed by `key_id`, unchanged).
- `Some(alias)` → seals/re-opens the PQC half under a **stable keystore alias** while the recorded/encoded `key_id` is the **derived** form.

The ML-DSA pubkey is a function of the sealed **seed** (under `seal_alias`), not the alias string, so the recorded record stays self-consistent and re-open by `seal_alias` reproduces it — **no custody migration, no lockout**.

## Unblocks the cross-repo USER-path fix
CIRISServer#45 can now record the responsible user under `derive_key_id("<alias>-user", ed_pub)` while sealing/re-opening under the stable `<alias>-user`. (CIRISPersist#247's node half already shipped in persist v9.3.0.)

## Wiring
- **FFI** `ciris_verify_create_federation_identity` parses optional `seal_alias` from the config JSON (non-breaking).
- **Python** binding documents it (config passthrough — already worked).
- **CLI** passes `None` (operators don't need the split).
- New test `seal_alias_decouples_recorded_key_id_from_seal_storage`: recorded id ≠ seal alias, and re-open by the alias reproduces the ML-DSA pubkey.

708 lib tests green; clippy + fmt + rustdoc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)