### PR TITLE
fix(crypto): ml-dsa 0.1.1 — outer SigningKey seed self-zeroizes + scrub from_seed_file (#87)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,7 @@ dependencies = [
  "oqs",
  "p256",
  "pbkdf2",
- "pkcs8 0.11.0-rc.11",
+ "pkcs8 0.11.0",
  "pretty_assertions",
  "proptest",
  "rand_chacha 0.3.1",
@@ -2690,17 +2690,17 @@ dependencies = [
 
 [[package]]
 name = "ml-dsa"
-version = "0.1.0-rc.8"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5b2bb0ad6fa2b40396775bd56f51345171490fef993f46f91a876ecdbdaea55"
+checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
 dependencies = [
  "const-oid 0.10.2",
+ "crypto-common 0.2.1",
  "ctutils",
  "hybrid-array",
  "module-lattice",
- "pkcs8 0.11.0-rc.11",
- "rand_core 0.10.1",
- "sha3 0.11.0",
+ "pkcs8 0.11.0",
+ "shake",
  "signature 3.0.0",
  "zeroize",
 ]
@@ -3151,9 +3151,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der 0.8.0",
  "spki 0.8.0",
@@ -4173,6 +4173,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4268,6 +4279,12 @@ dependencies = [
  "base64ct",
  "der 0.8.0",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"

--- a/src/ciris-crypto/Cargo.toml
+++ b/src/ciris-crypto/Cargo.toml
@@ -88,32 +88,26 @@ hkdf = "0.12"  # Key derivation
 hex = "0.4"    # Hex encoding for EVM addresses
 
 # Post-quantum (choose one via feature flag)
-# Pre-1.0 RC: pin EXACT (=). Caret semantics on a pre-1.0 crate allow
-# patch-level breaks, and ml-dsa rc.11 (2026-05-11) realized that risk —
-# removed `KeyGen` trait + `MlDsa65::from_seed` mid-stream, breaking every
-# downstream consumer that fresh-resolves Cargo deps. We compile and KAT-test
-# against rc.8 (matches the Cargo.lock at the v2.0.0 release). See
-# CIRISVerify#18 for the incident writeup.
-ml-dsa = { version = "=0.1.0-rc.8", optional = true, features = ["zeroize"] }
-# Zeroes the transient `Seed` in `from_seed` + zeroizes `ExpandedSigningKey` on
-# drop. NB rc.8 does NOT zeroize the outer `SigningKey.seed` (the raw seed lingers
-# for the signer's lifetime — upstream gap, AV-17 transient, tracked CIRISVerify#87).
+# Pin EXACT (=). The pre-1.0 RC line churned its API — rc.11 (2026-05-11)
+# removed the `KeyGen` trait + `MlDsa65::from_seed` mid-stream, breaking every
+# consumer that fresh-resolved Cargo deps (CIRISVerify#18). The stable 0.1.1
+# line settled seed construction on `SigningKey::from_seed` (used in
+# ml_dsa.rs) and — the reason for the bump (CIRISVerify#87) — made the OUTER
+# `SigningKey<P>` `ZeroizeOnDrop`: its `Drop` now scrubs the raw 32-byte
+# `seed` field, which rc.8 left un-zeroized for the signer's lifetime.
+ml-dsa = { version = "=0.1.1", optional = true, features = ["zeroize"] }
+# Zeroes the transient `Seed` in `from_seed`; with 0.1.1 the outer
+# `SigningKey.seed` is also `ZeroizeOnDrop` (CIRISVerify#87 closed).
 zeroize = { version = "1", optional = true }
 
-# v2.0.2: ml-dsa rc.8 transitively pulls pkcs8 via `^0.11.0-rc.11`, which
-# caret-resolves to `pkcs8 0.11.0` (stable, 2026-04-27). Between rc.11
-# (2026-02-11) and rc.12+stable (2026-04-27), pkcs8 changed
-# `Error::KeyMalformed` from a unit variant to a function-like variant
-# `KeyMalformed(KeyError)`. ml-dsa rc.8 still uses it as the unit form
-# in `.map_err(|_| ::pkcs8::Error::KeyMalformed)?,` at its lib.rs:200-206,
-# which under rc.12+/stable produces a function-pointer Result that `?`
-# can't convert. The last working point on the 0.11.x line is rc.11.
-# Forcing the resolver to pick rc.11 via this explicit top-level dep is
-# the federation crypto authority pattern in action: we own the
-# resolution of every crypto-transitive in one place. Tested: with this
-# pin, `rm -f Cargo.lock && cargo build` fresh-resolves cleanly. See
-# CIRISVerify#18 (reopened comment-stream).
-pkcs8 = { version = "=0.11.0-rc.11", optional = true, default-features = false }
+# v6.x (CIRISVerify#87): ml-dsa 0.1.1 (stable line) builds against the
+# stable `pkcs8 0.11.0`. The rc.8-era `=0.11.0-rc.11` pin existed only to
+# dodge an rc.8↔stable `Error::KeyMalformed` unit-vs-function mismatch in
+# ml-dsa's own source; ml-dsa 0.1.1 uses the stable variant correctly, so
+# the workaround is retired and we pin the stable `=0.11.0` to keep the
+# federation crypto authority pattern (one place owns every crypto-
+# transitive). Tested: `rm -f Cargo.lock && cargo build` fresh-resolves.
+pkcs8 = { version = "=0.11.0", optional = true, default-features = false }
 aws-lc-rs = { version = "1.5", features = ["unstable"], optional = true }
 
 # v2.0+ — symmetric / MAC primitives. PBKDF2 is a separate dep from hkdf

--- a/src/ciris-crypto/src/ml_dsa.rs
+++ b/src/ciris-crypto/src/ml_dsa.rs
@@ -18,7 +18,7 @@ use crate::hybrid::{PqcSigner, PqcVerifier};
 use crate::types::PqcAlgorithm;
 
 #[cfg(feature = "pqc-ml-dsa")]
-use ml_dsa::{EncodedVerifyingKey, KeyGen, MlDsa65, Seed, Signature, SigningKey, VerifyingKey};
+use ml_dsa::{EncodedVerifyingKey, MlDsa65, Seed, Signature, SigningKey, VerifyingKey};
 
 #[cfg(feature = "pqc-ml-dsa")]
 use ml_dsa::signature::{Keypair, Signer, Verifier};
@@ -104,19 +104,19 @@ impl MlDsa65Signer {
         let mut seed = Seed::try_from(seed)
             .map_err(|e| CryptoError::invalid_private_key(format!("Seed construction: {e}")))?;
 
-        // ml-dsa 0.1.0-rc.8: Use KeyGen trait's from_seed method
-        let signing_key = MlDsa65::from_seed(&seed);
+        // ml-dsa 0.1.1: `KeyGen::from_seed` was removed; seed-based
+        // construction now lives on `SigningKey` directly.
+        let signing_key = SigningKey::<MlDsa65>::from_seed(&seed);
         let verifying_key = signing_key.verifying_key();
         // Scrub the transient `Seed` copy we constructed.
         //
-        // NB (upstream limitation, ml-dsa rc.8): the `zeroize` feature makes only
-        // `ExpandedSigningKey` `ZeroizeOnDrop`, NOT the outer `SigningKey<P>`,
-        // which retains its own raw 32-byte `seed` un-zeroized for the signer's
-        // lifetime + on drop. We cannot reach that private field; closing it
-        // needs an ml-dsa upgrade (pinned to rc.8 per CIRISVerify#18). This in-
-        // memory residual is the AV-17 transient-software-PQC carve-out and
-        // affects EVERY software ML-DSA signer here, not just this path.
-        // Tracked: CIRISVerify#87.
+        // CIRISVerify#87 closed: ml-dsa 0.1.1's `zeroize` feature makes the
+        // OUTER `SigningKey<P>` `ZeroizeOnDrop` (its `Drop` zeroizes the raw
+        // 32-byte `seed` field), in addition to the `ExpandedSigningKey` that
+        // rc.8 already covered. The signer's own seed copy is therefore
+        // scrubbed on drop; we still zeroize this transient `Seed` here so the
+        // construction-time copy doesn't linger before `signing_key` takes
+        // ownership of its own clone.
         seed.zeroize();
         Ok(Self {
             signing_key,

--- a/src/ciris-crypto/src/types.rs
+++ b/src/ciris-crypto/src/types.rs
@@ -310,26 +310,29 @@ mod tests {
     #[cfg(feature = "pqc-ml-dsa")]
     #[test]
     fn test_pqc_signature_sizes_runtime_canary() {
-        use ml_dsa::signature::Signer;
-        use ml_dsa::{KeyGen, MlDsa44, MlDsa65, MlDsa87};
+        use ml_dsa::signature::{Keypair, Signer};
+        use ml_dsa::{MlDsa44, MlDsa65, MlDsa87, SigningKey};
 
         let seed = [0u8; 32].into();
 
-        let kp44 = MlDsa44::from_seed(&seed);
-        let sig44 = kp44.signing_key().sign(b"sig-size-canary");
-        let pk44 = kp44.signing_key().verifying_key().encode();
+        // ml-dsa 0.1.1: seed construction moved off the removed `KeyGen` trait
+        // onto `SigningKey::from_seed`, which returns the signing key directly
+        // (rc.8 returned a key pair with a `.signing_key()` accessor).
+        let sk44 = SigningKey::<MlDsa44>::from_seed(&seed);
+        let sig44 = sk44.sign(b"sig-size-canary");
+        let pk44 = sk44.verifying_key().encode();
         assert_eq!(sig44.encode().len(), PqcAlgorithm::MlDsa44.signature_size());
         assert_eq!(pk44.len(), PqcAlgorithm::MlDsa44.public_key_size());
 
-        let kp65 = MlDsa65::from_seed(&seed);
-        let sig65 = kp65.signing_key().sign(b"sig-size-canary");
-        let pk65 = kp65.signing_key().verifying_key().encode();
+        let sk65 = SigningKey::<MlDsa65>::from_seed(&seed);
+        let sig65 = sk65.sign(b"sig-size-canary");
+        let pk65 = sk65.verifying_key().encode();
         assert_eq!(sig65.encode().len(), PqcAlgorithm::MlDsa65.signature_size());
         assert_eq!(pk65.len(), PqcAlgorithm::MlDsa65.public_key_size());
 
-        let kp87 = MlDsa87::from_seed(&seed);
-        let sig87 = kp87.signing_key().sign(b"sig-size-canary");
-        let pk87 = kp87.signing_key().verifying_key().encode();
+        let sk87 = SigningKey::<MlDsa87>::from_seed(&seed);
+        let sig87 = sk87.sign(b"sig-size-canary");
+        let pk87 = sk87.verifying_key().encode();
         assert_eq!(sig87.encode().len(), PqcAlgorithm::MlDsa87.signature_size());
         assert_eq!(pk87.len(), PqcAlgorithm::MlDsa87.public_key_size());
     }

--- a/src/ciris-keyring/src/pqc.rs
+++ b/src/ciris-keyring/src/pqc.rs
@@ -192,8 +192,8 @@ impl MlDsa65SoftwareSigner {
     /// Create a signer from raw 32-byte ML-DSA-65 seed.
     ///
     /// The seed bytes are consumed into an `ml_dsa::SigningKey` via
-    /// `MlDsa65::from_seed`. This is the format the lens-steward bootstrap
-    /// uses (matches `dilithium-py`'s `from_seed`).
+    /// `SigningKey::<MlDsa65>::from_seed`. This is the format the lens-steward
+    /// bootstrap uses (matches `dilithium-py`'s `from_seed`).
     ///
     /// # Errors
     ///
@@ -248,10 +248,18 @@ impl MlDsa65SoftwareSigner {
     ) -> Result<Self, KeyringError> {
         let path = path.into();
         let alias = alias.into();
-        let bytes = std::fs::read(&path).map_err(|e| KeyringError::OperationFailed {
+        let mut bytes = std::fs::read(&path).map_err(|e| KeyringError::OperationFailed {
             reason: format!("reading ML-DSA-65 seed from {}: {e}", path.display()),
         })?;
-        let mut signer = Self::from_seed_bytes(&bytes, alias)?;
+        // CIRISVerify#87: `std::fs::read` lands the raw 32-byte ML-DSA seed in
+        // a heap `Vec<u8>` that lives past `from_seed_bytes` (which scrubs only
+        // its own stack copy). Scrub this file buffer on EVERY exit path —
+        // success or the error `?` below — using the crate-wide manual-fence
+        // idiom (see sealed_mldsa65.rs / usb_wrapped_mldsa65.rs).
+        let built = Self::from_seed_bytes(&bytes, alias);
+        bytes.iter_mut().for_each(|b| *b = 0);
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+        let mut signer = built?;
         signer.seed_path = Some(path);
         Ok(signer)
     }

--- a/src/ciris-keyring/src/usb_wrapped_mldsa65.rs
+++ b/src/ciris-keyring/src/usb_wrapped_mldsa65.rs
@@ -25,9 +25,9 @@
 //! [`crate::sealed_mldsa65`]. What this mode closes is **at-rest exfil +
 //! portability**: the USB seed is useless without the YubiKey, and the identity
 //! is no longer machine-bound (it travels on the two keys). The *in-memory*
-//! residual — that ml-dsa rc.8's `SigningKey` keeps the raw seed un-zeroized for
-//! its lifetime — is orthogonal, codebase-wide (every software ML-DSA signer),
-//! and tracked at CIRISVerify#87; it is **not** what this at-rest mode protects.
+//! residual that used to leave ml-dsa's outer `SigningKey` seed un-zeroized for
+//! its lifetime is orthogonal to this at-rest mode and was closed codebase-wide
+//! by the ml-dsa 0.1.1 bump (`SigningKey<P>: ZeroizeOnDrop`, CIRISVerify#87).
 //! When a FIPS ML-DSA token ships, this whole layer swaps for a hardware
 //! `PqcSigner` with no change above the trait.
 //!


### PR DESCRIPTION
## Summary

Bumps `ml-dsa` from the pinned `=0.1.0-rc.8` to stable `=0.1.1`, closing **#87**: rc.8's `zeroize` feature made only `ExpandedSigningKey` `ZeroizeOnDrop`, leaving the **outer `SigningKey<P> { seed, .. }`** holding a plaintext 32-byte ML-DSA seed for the signer's lifetime and un-scrubbed in freed memory on drop (AV-17 in-memory residual, affecting every software ML-DSA signer). ml-dsa 0.1.1 makes the outer `SigningKey<P>` `ZeroizeOnDrop` — its `Drop` zeroizes the raw `seed` field (verified in the vendored 0.1.1 `signing.rs`).

## Changes

- **`Cargo.toml`**: `ml-dsa = "=0.1.1"` (zeroize feature preserved); stale rc.8/KeyGen comments refreshed.
- **API relocation** (the reason the pin was stuck on rc.8 per #18 — rc.11 removed `KeyGen` + `MlDsa65::from_seed`):
  - `ml_dsa.rs`: `MlDsa65::from_seed(&seed)` → `SigningKey::<MlDsa65>::from_seed(&seed)`.
  - `types.rs` runtime size canary: `MlDsaNN::from_seed(..).signing_key()` → `SigningKey::<MlDsaNN>::from_seed(..)` (0.1.1 returns the signing key directly, not a key pair). Byte-size + determinism asserts unchanged and pass → FIPS 204 / `dilithium-py` byte-compatibility preserved.
- **pkcs8 workaround retired**: the `=0.11.0-rc.11` pin only dodged an rc.8↔stable `Error::KeyMalformed` unit-vs-function mismatch inside ml-dsa's own source. 0.1.1 uses the stable variant correctly, so the pin moves to stable `=0.11.0` (one place still owns the crypto-transitive).
- **`pqc.rs::from_seed_file`**: the `std::fs::read` seed `Vec<u8>` outlived `from_seed_bytes` (which scrubs only its stack copy). Now scrubbed on every exit path using the crate-wide manual-fence idiom (matching `sealed_mldsa65.rs` / `usb_wrapped_mldsa65.rs`) — no lone `zeroize` direct dep introduced into ciris-keyring.
- Refreshed the now-stale `usb_wrapped_mldsa65.rs` doc note (the in-memory residual it referenced is closed by this bump).

## Verification

- `cargo build` + `cargo test --lib` green for **ciris-crypto** + **ciris-keyring** under `pqc-ml-dsa` and the full CI `crypto-features` set (**160** + **106** tests pass).
- `cargo clippy -p ciris-crypto -p ciris-keyring --lib -- -D warnings` clean.
- `cargo fmt --all` applied; all pre-commit hooks pass.
- `cargo deny check advisories` → **ok**; no new advisories from ml-dsa 0.1.1 / pkcs8 0.11.0 / shake / sponge-cursor.

## MSRV / advisory status

- **MSRV intact**: ml-dsa 0.1.1 declares `rust-version = "1.85"` ≤ workspace MSRV **1.86** (edition 2024, supported since 1.85). No MSRV bump.
- Cargo.lock resolves cleanly: `ml-dsa` rc.8→0.1.1, `pkcs8` rc.11→0.11.0, + new transitives `shake` / `sponge-cursor`.
- No rc.8/ml-dsa/pkcs8-specific advisory ignore existed in `deny.toml`, so none retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)