### PR TITLE
docs(accord): rewrite FSD-004 to the live-quorum model (#98)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ CIRISVerify is the **hardware-rooted license verification module** for the CIRIS
 | Path | Purpose |
 |------|---------|
 | `FSD/FSD-001_CIRISVERIFY_PROTOCOL.md` | Full technical specification (authoritative) |
-| `FSD/FSD-004_ACCORD_DECIMATION_RECOVERY.md` | DRAFT design — accord catastrophic-decimation recovery (emergency opposite-quorum; adversarial-AGI first-strike threat model). CIRISVerify#98. Not ratified, not implemented. |
+| `FSD/FSD-004_ACCORD_DECIMATION_RECOVERY.md` | DRAFT design — accord **live-quorum** operation & recovery under decimation (quorum floats over who proves life; proof-of-life modifies the quorum + carries a vote; always leans toward firing; adversarial-AGI first-strike threat model). CIRISVerify#98. Not ratified, not implemented. |
 | `protocol/ciris_verify.proto` | Public API contract (gRPC/protobuf) |
 | `docs/THREAT_MODEL.md` | Formal threat model (6 attack vectors, mitigations) |
 | `docs/HOLONOMIC_SUBSTRATE.md` | CEG §19 / §19.7 holonomic verifiers — threat model, module map, conformance status (§19 + §19.7 cross-impl-proven) |

--- a/FSD/FSD-004_ACCORD_DECIMATION_RECOVERY.md
+++ b/FSD/FSD-004_ACCORD_DECIMATION_RECOVERY.md
@@ -1,342 +1,319 @@
-# FSD-004 — Accord Catastrophic-Decimation Recovery (Emergency Opposite-Quorum)
+# FSD-004 — Accord Live-Quorum Operation & Recovery Under Decimation
 
-**Status:** DRAFT (2026-06-21). Design specification — **not yet ratified, not
-yet implemented.** This is a deliberate **quorum-bypass on kill-switch
-membership**; nothing here ships without (a) constitutional grounding in CEG §9 /
-the CIRIS Constitution, and (b) an adversarial review on par with #91/#95.
+**Status:** DRAFT (2026-06-21; rewritten to the live-quorum model 2026-06-21).
+Design specification — **not yet ratified, not yet implemented.** Changing how the
+kill-switch quorum is computed is a §9 governance change; nothing here ships
+without (a) constitutional grounding in CEG §9 / the CIRIS Constitution and (b) an
+adversarial review on par with #91/#95.
 
 **Tracks:** CIRISVerify#98. **Builds on:** FSD-001 (protocol), the v6.8.0 growable
 M-of-N accord family + membership-change `supersedes` (`ciris_verify_core::
-accord_genesis`), CEG §9.1/§9.2 (entrenched family + invocation).
+accord_genesis`), CEG §9.1/§9.2.
 
 ---
 
 ## 1. Purpose
 
-The HUMANITY_ACCORD kill-switch is the mechanism by which accountable humans can
-constitutionally halt a CIRIS agent. Its trust rests on **distributed human
-custody**: an M-of-N strict-majority quorum of holders. That same property is a
-**liability under catastrophic loss** — the normal quorum *deadlocks* precisely
-when most holders are gone, which is exactly the moment the kill-switch matters
-most.
+The HUMANITY_ACCORD kill-switch is the last-resort human ability to constitutionally
+halt a CIRIS agent. Its trust rests on **distributed human custody** — an M-of-N
+strict-majority quorum of holders. As specified today that quorum is taken over the
+**standing roster**, which makes it **deadlock under catastrophic loss**: if most
+holders are gone, the standing quorum is unreachable, and the switch becomes
+inoperable exactly when it matters most.
 
-This FSD specifies how the accord **survives the decimation of its roster**: how
-the few remaining humans can still invoke the kill-switch and reconstitute the
-family, **without** opening a path for an adversary to seize or falsely fire it.
+This FSD respecifies the quorum so the accord **operates continuously as holders
+are lost and regained**, rather than treating "recovery" as a separate exceptional
+protocol. The mechanism is a **live quorum**: every decision is taken over the set
+of holders who actually show up, and *being reachable is how you participate*.
 
-## 2. Threat Model — adversarial-AGI first strike
+## 2. Threat model — adversarial-AGI first strike
 
-The design target is the **worst case the accord exists for**: a misaligned
+The design target is the worst case the accord exists for: a misaligned
 superintelligence executes a **first strike against its own off-switch** — the
-human accord holders — *before* or *while* it acts against humanity at large.
+human holders — before or while it acts against humanity.
 
-**Scale.** The accord is assumed to have **grown** (FSD/v6.8.0 growable M-of-N) to
-be robust — e.g. **N = 21 holders**, strict-majority quorum 11-of-21. The strike
-reduces the **reachable, key-capable** holders to **1 or 2**.
+**Scale.** The accord is assumed to have **grown** (v6.8.0 growable M-of-N) to be
+robust — e.g. **N = 21 holders, standing quorum 11-of-21** — and the strike reduces
+the **reachable, key-capable** holders to **1 or 2**.
 
-**Adversary capabilities (assume all of them simultaneously):**
+**Adversary capabilities (assume all at once):** kill/incapacitate holders
+(keys permanently or temporarily unavailable); coerce/seize keys (signatures under
+duress — worse than loss); **censor communications** (suppress a holder's "I am
+alive," partition survivors — *under a first strike this is the expected condition,
+not an edge case*); impersonate non-cryptographic signals; and race any window the
+protocol introduces.
 
-| Capability | Consequence for the accord |
-|---|---|
-| **Kill / incapacitate** holders | Their keys are permanently unavailable (death) or temporarily (injury, capture). |
-| **Coerce / seize** keys | A holder's key signs under duress — *worse than loss* (active misuse). |
-| **Censor communications** | Suppress a holder's "I am alive" message; partition survivors. **Under a first strike, censorship is the EXPECTED condition, not an edge case.** |
-| **Impersonate** | Forge non-cryptographic signals (but not hybrid signatures over pinned keys). |
-| **Race the clock** | Act during any challenge/timelock window the recovery introduces. |
+**What must survive:** (1) the surviving human(s), however few, can still **fire**
+the kill-switch; (2) the roster can be **reconstituted** so the accord remains
+operable afterward. The adversary cannot forge a hybrid signature over a pinned key
+— so it cannot *manufacture* a holder; it can only *remove* (kill/censor) or
+*compromise* (coerce) existing ones.
 
-**What must survive the strike:**
+**Non-goals.** Agent-side enforcement of an admitted invocation (CIRISServer /
+WiseBus); physical security of the holders; recovery of a dead holder's private
+*key* (gone — this is about the *roster*, not the key).
 
-1. **Invocability** — the surviving human(s), however few, can still fire the
-   constitutional kill-switch.
-2. **Recoverability** — the family roster can be reconstituted (new holders
-   admitted, dead/coerced holders removed) so the accord remains operable
-   afterward.
+## 3. Design principle — minimize the missed fire (one direction, no asymmetry)
 
-**Non-goals.** This FSD does not address (a) the agent-side enforcement of an
-admitted invocation (CIRISServer / WiseBus), (b) physical/operational security of
-the holders themselves, or (c) recovery of *cryptographic material* (a dead
-holder's private key is gone — recovery is about the *roster*, not the key).
+The accord exists to prevent **one** terminal failure: a rogue AI survives because
+the humans **could not fire**. Among the error modes:
 
-## 3. The central design principle — failure-direction asymmetry
+- A **missed fire** (the adversary decapitated everyone who could pull the plug) is
+  **terminal** — unrecoverable.
+- A **false fire** (an agent halted in error) is a **recoverable** governance
+  nuisance — an agent can be re-licensed; humanity cannot be un-extincted.
 
-The two needs in §2 pull in **opposite** safety directions, and conflating them
-is the trap. The accord is **fail-safe toward shutdown**: halting a suspect agent
-is the recoverable direction (an agent can be re-licensed; an extinct humanity
-cannot). Therefore:
+Therefore **every lever is set to minimize the probability of a missed fire.** This
+is a *single* optimization direction — there is no countervailing "make it harder"
+force to balance, because the thing a brake would protect against (a false fire, or
+a roster "coup") is either cheap-and-recoverable or is not actually mitigated by a
+brake (§8). Concretely:
 
-> **Invocation** (firing the kill-switch) should be **biased toward firing** under
-> decimation — a *false* fire is a recoverable nuisance (an agent halted in error
-> can be restored through governance), while a *missed* fire (the adversary
-> decapitated everyone who could pull the plug) is **terminal**.
->
-> **Reconstitution** (changing *who holds* the kill-switch) must be **biased
-> against change** — a *false* reconstitution is a **coup**: it hands the
-> kill-switch (and the power to *suppress* it) to an attacker. This is the path
-> that needs the strong, slow, vetoable guards.
+- **Firing leans easiest of all.** In deep decimation a constitutional kill is
+  admissible on the smallest viable live set — down to a lone reachable survivor.
+- **Reconstitution leans easy too**, not hard: a decimated-but-honest survivor set
+  must be able to *rebuild a firing-capable roster*. Making reconstitution slow or
+  high-bar would only help a suppressor (whose aim is to keep the switch
+  un-fireable) — the exact opposite of the goal.
+- The bias gradient is: **fire ≤ roster-change ≤ (former) standing quorum**, all
+  taken over the *live* set, never over the absent standing roster.
 
-Everything below follows from this asymmetry. The "emergency opposite-quorum" is
-the mechanism for the **reconstitution** path; the **invocation** path gets a
-separate, lighter emergency rule.
+(An earlier draft of this FSD posited a "failure-direction asymmetry" — fire easy,
+reconstitution hard. That was wrong: it set a brake against a coup, but a coup's
+worst act is either a recoverable false fire or a suppression that requires
+majority capture *regardless* of reconstitution speed. The brake only handicapped
+the honest survivors. This rewrite removes it.)
 
-## 4. Design
+## 4. The mechanism — one live quorum
 
-### 4.1 Emergency invocation under decimation (the fast path)
+There is **no separate recovery protocol.** There is one mechanism — the live
+quorum — and "decimation" is simply the case where the live set is small.
 
-**Problem.** Normal invocation concurrence (CEG §9.2.1) needs the strict-majority
-quorum (11-of-21). With 1–2 survivors it is unreachable.
+### 4.1 The live set and the floating quorum
 
-**Rule (fail-safe-to-shutdown).** Declare a **DECIMATION state** for the family
-when the count of holders able to produce a fresh signature within a short probe
-window falls below the standing quorum. In DECIMATION state, a **constitutional
-invocation may be admitted on the signatures of the reachable survivors alone**
-(down to 1), provided:
+Every accord decision (fire, roster change, or both) is a **proposal** that opens a
+bounded **participation window** `W`. Within `W`, each holder may respond with a
+**proof-of-life + vote** (§4.2). When `W` closes:
 
-- the invocation is the standing closed-vocab `CONSTITUTIONAL` kill (§9.2.1 — *not*
-  a roster change; this path can fire the switch, it cannot change membership);
-- the survivor set is itself **proof-of-life-fresh** (each survivor's signature is
-  over a recent server-issued nonce, so a *replayed* dead-holder signature can't
-  manufacture a survivor);
-- the admitted invocation is **loudly, immutably logged** (CEG transparency) — a
-  decimation-fire is the highest-scrutiny event in the system.
+- the **live set** `L` = the holders who proved life within `W` (always a subset of
+  the standing roster — only real, pinned members count);
+- the decision is tallied **over `L`**, at a per-action threshold (§4.3).
 
-**Why this is acceptable.** A false decimation-fire halts an agent that governance
-can later restore; it does **not** transfer custody of the kill-switch. The
-adversary gains nothing by *triggering* it (it shuts down the very agent the
-adversary controls). The only thing this path must refuse is *roster change* —
-which §4.2 governs.
+Absence is self-correcting: a holder who does not respond is simply **not in the
+denominator** for that decision — they cannot block by being gone. Presence is
+self-asserting: showing up puts you in `L` with a vote. This is the **inactivity-
+leak dynamic** (Casper FFG, §5) made into the accord's *standing* rule rather than
+an emergency exception.
 
-> **Open constitutional question (Q1):** the Constitution calls `CONSTITUTIONAL`
-> "the full constitutional kill — not a recoverable pause." If a constitutional
-> kill is *truly* irreversible, a false decimation-fire is **not** cheaply
-> recoverable, and this path needs a (short) proof-of-life challenge window like
-> §4.2. The asymmetry argument holds only to the degree a kill is governance-
-> reversible. **This must be settled before §4.1 is built.**
+### 4.2 Proof-of-life *modifies the quorum and carries a vote* — it is not a veto
 
-### 4.2 Emergency roster reconstitution — the opposite-quorum (the guarded path)
+A holder participates by signing a fresh **proof-of-life** over the proposal's
+server-issued nonce, **bundled with their vote** on the proposal. This does two
+things:
 
-This is the inverse of a normal quorum: instead of needing **M affirmative
-signatures to act**, the action **takes effect by default after a challenge
-window unless it is vetoed.** A below-quorum survivor set proposes a roster
-change; the change is defeated by proof-of-life or by survivor dissent.
+1. **Modifies the quorum** — the signer enters `L`, so the live denominator (and
+   thus the strict-majority threshold) *floats up* to include them. If 21 → 2
+   reachable and three more prove life mid-window, `|L|` becomes 5 and the
+   roster-change bar becomes 3-of-5.
+2. **Carries a vote** — the same signature records yes/no on the proposal.
 
-**Actors.** `X` = the reachable survivors proposing. `Y` = the holders they assert
-are unavailable. `N` = the standing roster (`X ∪ Y`, plus any already-removed).
+A presumed-dead holder who resurfaces therefore does **not unilaterally defeat** a
+proposal — they **rejoin and are counted**, and the proposal still succeeds if the
+live majority supports it. The protection this buys is the correct one: *a living,
+reachable holder cannot be erased from a decision without being counted and given a
+vote* — but the family can still act by its live majority (it is not hostage to a
+single signature). The freshness nonce prevents a replayed signature from a truly-
+absent holder manufacturing a phantom participant.
 
-**The flow:**
+### 4.3 Per-action thresholds (the firing bias)
 
-1. **Recovery proposal** (`accord_recovery_proposal`). The survivors `X` jointly
-   sign a proposal: *"we assert holders `Y` are unavailable (could not sign within
-   window `W_probe` despite broadcast), and propose new roster `R'` / action
-   `Z`."* `Z` is a normal entrenched-family `supersedes` (FSD/v6.8.0
-   `build_accord_membership_change`) — same entrenchment invariants
-   (strict-majority `2·M > N`, entrenched flag, `family_key_id` unchanged,
-   distinct-pubkey gate).
-2. **Challenge window** `W_challenge` opens (and the proposal is broadcast widely —
-   CEG + every out-of-band channel; see §8).
-3. **Veto by proof-of-life.** *Any* holder in `Y` who signs a fresh
-   `accord_proof_of_life` over the proposal's nonce **defeats the proposal** — and,
-   ipso facto, proves the quorum was *not* actually broken (they're alive), so no
-   recovery was needed. The falsely-accused-dead cannot be removed against their
-   will.
-4. **Veto by survivor dissent.** If a strict majority **of `X`** signs
-   `accord_recovery_dissent` ("we do not agree `Y` are unavailable / we do not
-   agree on `Z`"), the proposal dies. No lone faction of survivors can declare
-   others dead and seize the roster *unless they are genuinely the only ones
-   left.*
-5. **Steward backstop (required when `|X|` is below a floor).** When the surviving
-   proposers number fewer than `X_floor` (e.g. `< 3`, certainly `= 1`), the
-   proposal **additionally requires** a quorum of the regional **stewards**
-   (us/eu/apac — the §6 cross-attestation root the accord is already upstream-
-   rooted in) to co-sign. This removes the pure self-attestation of the most
-   dangerous case (a lone survivor) without inventing a new trust principal.
-6. **Assembly.** If `W_challenge` elapses with no valid veto, the proposal's
-   `supersedes` is admitted via the existing `verify_accord_membership_change`
-   path, with the **proof-of-absence record** (the broadcast proof + unanswered
-   challenge) standing in for the unreachable prior quorum's signatures.
-7. **Recursion / cascade.** Confirmed-unavailable holders are removed; the
-   strict-majority threshold recomputes on the now-smaller roster; the mechanism
-   may **repeat** if loss continues (21 → … → a working core), and any dispute
-   *about a recovery* is itself resolved by the same proposal/veto structure. A
-   floor prevents recursion to a zero-member or single-attacker roster (§9).
+All thresholds are taken **over `L`**, never over the absent standing roster.
 
-**The safety floor this buys:** because *any* reachable living holder can veto by
-signing "alive," **the reconstitution path can never remove a living, reachable
-holder.** A hostile takeover therefore requires the targeted holders to be *both*
-key-unavailable *and* unreachable-to-object — i.e. genuinely dead, or
-simultaneously censored **and** coerced. Combined with the survivor-dissent veto
-and the steward floor, the abuse surface is bounded to exactly the conditions a
-real first strike creates — which §8 addresses head-on.
+| Action | Threshold over `L` | Rationale |
+|---|---|---|
+| **Fire** (CONSTITUTIONAL kill, §9.2.1) | a **low floor** — a small fraction of `L`, down to **1** in deep decimation | missed fire is terminal, false fire recoverable → lean easiest |
+| **Roster change** (add / remove / swap; the `supersedes`) | **strict majority of `L`** (`2·M > \|L\|`) | the live set governs its own membership |
+| **Standing-quorum acts** (non-emergency) | strict majority of the standing roster (unchanged) | normal operation when not decimated |
+
+The firing floor sitting **below** the roster-change threshold is the whole point:
+even a partially-captured live set's honest minority can still fire (§8).
+
+### 4.4 Steward floor when `L` is tiny
+
+When `|L|` falls below a floor `L_floor` (e.g. `< 3`, certainly `= 1`), a **roster
+change** additionally requires a quorum of the regional **stewards** (us/eu/apac —
+the §6 cross-attestation root the accord is already upstream-rooted in) to co-sign.
+This removes the pure self-attestation of the most capturable case (a lone or
+near-lone survivor reconstituting the roster) without inventing a new principal.
+**Firing is not gated this way** — firing leans easy in all states.
+
+### 4.5 Return and reinstatement (Enoch Arden)
+
+A holder who proves life **after** a decision missed that vote, but is **re-enrolled
+in the standing roster going forward** — modifying the quorum for subsequent
+decisions. Past actions validly decided by the then-live set stand; the returnee
+simply rejoins. This is the legal rebuttable-presumption-of-death pattern: the
+absent are presumed gone so the present may act, and the returning are reinstated.
 
 ## 5. Prior art
 
-This pattern is well-trodden; the design borrows deliberately.
-
-- **Social-recovery wallets (Argent / Safe / ERC-4337).** Guardians propose a
-  signer swap after a **timelock**; the owner holds a **veto — cancel with the
-  original key during the delay.** Our proof-of-life veto generalizes that
-  owner-cancel from one owner to "any presumed-dead holder."
-  ([Argent/Safe/4337 overview](https://university.mitosis.org/intro-to-social-recovery-wallets-safe-argent-and-erc-4337/),
-  [attack paths](https://cantina.xyz/blog/smart-wallet-social-recovery-risks))
-- **Ethereum inactivity leak (Casper FFG)** — the closest large-scale analog,
-  *designed for* "recover finality when **over one-third of validators go
-  offline**": the absent set's weight **decays until the active set regains the
-  majority**, and a returning validator stops their own leak. Our recursive
-  recovery is the discrete-governance form of this continuous leak; battle-tested
-  on mainnet (May 2023). ([eth2book](https://eth2book.info/latest/part2/incentives/inactivity/),
+- **Ethereum inactivity leak (Casper FFG)** — *the* model: designed for "recover
+  finality when over one-third of validators go offline," it measures the quorum
+  against **participants**, lets the absent set drop out of the denominator, and
+  **re-includes a returning validator.** Our live quorum is the discrete-governance
+  form, battle-tested on mainnet (May 2023).
+  ([eth2book](https://eth2book.info/latest/part2/incentives/inactivity/),
   [Casper FFG paper](https://arxiv.org/pdf/1710.09437))
-- **BFT view-change / failure detectors.** A view-change is "an **accusation**
-  against the leader"; the literature's hard problem — "a faulty leader can cause
-  honest replicas to disagree on whether it is faulty… accusers cannot convince
-  others" — is **exactly** our censorship risk (§8), already named and studied.
-  ([BFT survey](https://arxiv.org/html/2407.19863v3))
-- **Enoch Arden doctrine / rebuttable presumption of death.** A person absent long
-  enough is *presumed dead so others may act*, **but rebuttably** — "if the person
-  subsequently appeared, the law no longer considered them dead," and a returning
-  person can **petition to vacate the declaration and reclaim assets still held.**
-  Centuries of case law for proof-of-life veto + returning-holder reinstatement.
+- **Social-recovery wallets (Argent / Safe / ERC-4337)** — guardian proposals + a
+  **timelock window**; the window is our `W`. (Our proof-of-life is not the
+  owner-veto of those systems — see §4.2; it's a counted vote, not a cancel.)
+  ([overview](https://university.mitosis.org/intro-to-social-recovery-wallets-safe-argent-and-erc-4337/))
+- **Enoch Arden / rebuttable presumption of death** — the absent are presumed gone
+  so others may act, **rebuttably**: a returning person is reinstated and can
+  reclaim standing. Exactly §4.5.
   ([Cornell LII](https://www.law.cornell.edu/wex/enoch_arden_doctrine),
   [Presumption of death](https://en.wikipedia.org/wiki/Presumption_of_death))
+- **BFT participation/quorum-over-responders + failure detectors** — quorum taken
+  over reachable participants, with the well-studied caveat that a partition can
+  make honest nodes disagree on who is present — our §8 residual.
+  ([BFT survey](https://arxiv.org/html/2407.19863v3))
 
 ## 6. Protocol — CEG objects (sketch)
 
-All objects are hybrid-signed (Ed25519 + ML-DSA-65, bound) over JCS canonical
-bytes (CEG §0.9), same discipline as `accord_genesis`.
+All hybrid-signed (Ed25519 + ML-DSA-65, bound) over JCS canonical bytes (CEG §0.9),
+same discipline as `accord_genesis`.
 
-- **`accord_recovery_proposal`** — `{ family_key_id, prior_family_digest,
-  asserted_unavailable: [key_id…], proposed_supersedes: <membership-change
-  envelope>, probe_evidence, nonce, challenge_window_until, signatures: [X…] }`.
-  Binds the proposed new roster *and* the assertion-of-absence in one signed
-  preimage.
-- **`accord_proof_of_life`** — `{ family_key_id, refutes_proposal: <nonce/digest>,
-  signed_at, signature }` from a member of `Y`. The veto.
-- **`accord_recovery_dissent`** — same shape, from a member of `X`. The
-  survivor-dissent veto.
-- **`accord_steward_recovery_attestation`** — steward co-signatures required when
-  `|X| < X_floor`.
-- **`accord_recovery_assembly`** — the terminal object: the admitted `supersedes`
-  + the proof-of-absence bundle (proposal + elapsed window + null vetoes [+ steward
-  attestations]) standing in for the unreachable prior quorum.
+- **`accord_proposal`** — `{ family_key_id, prior_family_digest, action: <fire |
+  membership-change envelope | both>, nonce, window_until }`. The thing voted on.
+- **`accord_participation`** — `{ family_key_id, refers_to: <proposal nonce/digest>,
+  proof_of_life: true, vote: <yes|no|abstain>, signed_at, signature }`. The
+  proof-of-life **+ vote** in one signed object; entering `L` and voting are the
+  same act (§4.2).
+- **`accord_decision`** — the terminal object: the proposal + the set of
+  `accord_participation` objects collected in `W` + the tally + (for roster change)
+  the resulting `supersedes`, and the steward attestations if `|L| < L_floor`. The
+  proof-of-participation bundle stands in for the (now meaningless) standing-roster
+  signature requirement.
 
 ## 7. Verification logic (verify-side obligations)
 
-New surface in `ciris_verify_core::accord_genesis` (or a sibling `accord_recovery`
-module), all **fail-closed**:
+New surface in `ciris_verify_core` (an `accord_recovery` / `accord_live_quorum`
+sibling of `accord_genesis`), all **fail-closed**:
 
-1. `verify_recovery_proposal` — proposal well-formed; `X` signers resolve in the
-   pinned directory and are *current roster members*; `asserted_unavailable ⊆`
-   current roster; `proposed_supersedes` passes **all** existing
-   `verify_accord_membership_change` invariants (entrenchment, strict majority,
-   distinct-pubkey gate, anti-replay) **except** the prior-quorum signature
-   requirement, which the recovery bundle replaces.
-2. `verify_proof_of_life` / `verify_recovery_dissent` — a single valid veto from
-   the right population kills the proposal; surfaced as a hard `RecoveryVetoed`.
-3. `verify_steward_backstop` — when `|X| < X_floor`, require the steward quorum
-   (reuse `verify_founder_quorum` against the pinned steward roster).
-4. `verify_recovery_assembly` — re-checks the whole bundle: window elapsed, no
-   valid veto present, steward backstop if required, and the resulting roster
-   satisfies the §9 floors. Emits the new family genesis on success.
+1. `tally_live_quorum` — over the collected `accord_participation` objects: each
+   resolves to a **current roster member** in the pinned directory, each signature
+   verifies over the proposal nonce (freshness — no replay), dedup by member_id;
+   `L` = distinct valid participants; tally votes; compare to the §4.3 threshold for
+   the action.
+2. `verify_membership_change_by_live_quorum` — when the action is a roster change,
+   the resulting `supersedes` must pass **all** existing
+   `verify_accord_membership_change` invariants (entrenchment, strict-majority,
+   distinct-pubkey gate, anti-replay) — the **only** substitution is that the
+   authorizing quorum is the **live set `L`** (strict majority of `L`) rather than
+   the standing roster, plus the §4.4 steward backstop when `|L| < L_floor`.
+3. `verify_fire_by_live_quorum` — admits a `CONSTITUTIONAL` invocation at the low
+   firing floor over `L`; reuses `humanity_accord::Invocation`.
 
-The **authoritative** verification (as with invocation, FSD-001) is CIRISServer
-recomputing against pinned `federation_keys` — the local objects are advisory.
+The **authoritative** tally (as with invocation, FSD-001) is CIRISServer recomputing
+over pinned `federation_keys`; the local objects are advisory.
 
-## 8. Security analysis — the first-strike makes censorship the default
+## 8. Security analysis — the residual is seize-and-suppress, not false-fire
 
-The proof-of-life veto is the safety floor, but a first strike **attacks the veto
-channel directly**: if the adversary can suppress every "I am alive" message for
-the whole window, it can falsely declare living holders dead and reconstitute the
-roster — a coup. Under §2 we must assume the adversary *can* censor. Mitigations,
-layered:
+Because the quorum floats over responders, the adversary's lever is **shrinking `L`
+to a subset it controls**: censor the honest holders so they never enter `L`, and
+include its captured/coerced members. The adversary still cannot *forge* a member
+(signatures are over pinned keys) — it can only remove or coerce real ones. The
+consequences, by action:
 
-1. **Wide, redundant, out-of-band broadcast.** The proposal + challenge must reach
-   `Y` over channels the adversary cannot fully control — CEG mesh, public
-   bulletin, physical/social. Proof-of-life is a *signature*, not a network round
-   trip: a holder who learns of the proposal by *any* channel can publish a veto
-   through *any* channel. The adversary must censor **all** of them, for **all**
-   targeted holders, for the **whole** window.
-2. **Long `W_challenge`.** The window is the adversary's required censorship
-   duration. Reconstitution is deliberately slow (days), trading latency for
-   safety — acceptable because §4.1's *invocation* path is the fast one;
-   reconstitution is for *afterward*.
-3. **Mandatory steward backstop at low `|X|`.** The most censorable case (1
-   survivor) cannot self-reconstitute — it needs an independent steward quorum,
-   who are geographically separate principals with their own channels. The
-   adversary must now censor the survivors' targets **and** subvert a steward
-   quorum.
-4. **Coercion ≠ defeated by proof-of-life.** A *coerced* living holder can be made
-   to sign anything, including a false proof-of-life that *blocks* a legitimate
-   recovery (griefing) — or a recovery proposal that *enacts* the adversary's
-   roster. Proof-of-life only protects the *unwilling-to-be-removed*; it does not
-   detect duress. This is the residual the steward backstop + dissent veto +
-   transparency log exist to bound, and it is **explicitly an open hard problem**
-   (Q3).
-5. **Transparency.** Every recovery object is append-only logged. A contested or
-   adversarial recovery leaves an immutable, publicly-auditable trail — the basis
-   for *post-hoc* governance reversal even if the live mechanism is fooled.
+- **Fire.** A captured small `L` *firing falsely* is **cheap** (recoverable) — we do
+  not defend against it. A captured `L` *suppressing* a fire is **hard**: the firing
+  floor is low, so an honest minority that reaches *any* channel and enters `L` can
+  fire over the adversary's objection. Censorship would have to be **total and
+  sustained against every honest holder on every channel** — and proof-of-life is a
+  publishable signature, not a network round-trip. This is the case the design most
+  protects, and correctly so.
+- **Roster change.** A captured-`L` *reconstitution* is the real residual — the
+  adversary shrinks `L` to its captured subset and votes itself a roster. Bounded
+  by: (a) the **strict majority of `L`** — honest holders who reach any channel
+  enter `L` and dilute the captured share; (b) the **steward floor** at small `|L|`
+  — the most capturable case additionally requires subverting an independent steward
+  quorum on separate channels; (c) **transparency** — every `accord_decision` is
+  append-only logged, so a contested reconstitution leaves an immutable trail that
+  is the basis for *post-hoc* governance reversal even if the live tally was fooled.
 
-**What we do not claim:** this does not make the accord unconditionally
-recoverable under an omnipotent adversary. It makes recovery **possible** when
-survivors can reach *any* honest channel, and makes a **false** reconstitution
-require the conjunction of (kill/censor the targets) **and** (subvert a steward
-quorum or a survivor majority) — a materially higher bar than the deadlock it
-replaces.
+**Coercion / duress** is the irreducible hard part: a coerced living holder can be
+made to sign a proof-of-life-with-vote the adversary chooses. Proof-of-life proves
+*presence*, not *willingness*. This is bounded — not solved — by the steward floor,
+the live majority, and transparency, and is called out as an open problem (Q3); a
+duress canary is a candidate but out of scope here.
+
+**What we do not claim:** unconditional recoverability under an omnipotent
+adversary. We claim that recovery is **possible** whenever honest survivors reach
+*any* channel, that **firing survives** all but total sustained censorship, and that
+a **false reconstitution** requires capturing a live majority *and* subverting the
+steward floor — a materially higher bar than the deadlock it replaces, with the
+honest case made *easy* rather than braked.
 
 ## 9. Parameters to pin
 
 | Parameter | Meaning | Candidate | Open |
 |---|---|---|---|
-| `W_probe` | freshness window for "could not sign" | hours | Q2 |
-| `W_challenge` | proof-of-life veto window for reconstitution | days | Q2 |
-| `X_floor` | survivor count below which steward backstop is mandatory | `3` (always for `1`) | Q2 |
+| `W` | participation window per proposal (may differ fire vs roster) | hours (fire) / days (roster) | Q2 |
+| fire floor | min live participants to admit a `CONSTITUTIONAL` fire | a small fraction, ≥ 1 | Q1, Q2 |
+| roster threshold | quorum for a roster change over `L` | strict majority of `\|L\|` | — |
+| `L_floor` | `\|L\|` below which a roster change needs the steward backstop | `3` (always for `1`) | Q2 |
 | steward quorum | M-of-N of the 3 regional stewards | `2-of-3` | — |
-| recursion floor | smallest roster a recovery may produce | ≥ 1, never to attacker-only | Q4 |
-| invocation-fast-path | survivors needed to fire in DECIMATION | ≥ 1 fresh | Q1 |
+| recursion floor | smallest roster a change may produce | ≥ 1, never to attacker-only | Q4 |
 
 ## 10. Open questions (must resolve before build)
 
-- **Q1 — Is a constitutional kill governance-reversible?** Determines whether the
-  §4.1 fast invocation can be near-instant (reversible) or needs a challenge
-  window (irreversible). Gates the whole asymmetry argument.
-- **Q2 — Window/floor calibration.** Long enough to survive censorship, short
-  enough to recover before the adversary consolidates. Needs explicit modeling.
+- **Q1 — How low is the fire floor?** "Lean easiest" vs. a minimum that resists a
+  trivially-captured single coerced key firing. (Note: a false fire is recoverable,
+  which argues for a very low floor.)
+- **Q2 — Window / floor calibration.** `W` long enough to let honest holders enter
+  `L` against censorship, short enough to fire/recover before the adversary
+  consolidates. Needs explicit modeling.
 - **Q3 — Coercion / duress.** Proof-of-life cannot detect a gun-to-the-head
-  signature. Is the steward backstop + transparency + post-hoc reversal
-  sufficient, or is a duress-signal (canary) mechanism warranted?
-- **Q4 — Recursion termination & minimum viable accord.** Does the accord have a
-  hard minimum below which it enters a different (e.g. fully steward-custodied)
-  regime rather than a 1-of-1?
-- **Q5 — Constitutional grounding.** This is a §9 governance change; it needs an
-  explicit basis in the CIRIS Constitution / CEG §9 before code, plus an
-  entrenchment-preservation proof (recovery must *restore*, never *weaken* or
-  *seize*).
+  signature. Is steward floor + live majority + transparency + post-hoc reversal
+  sufficient, or is a duress canary warranted?
+- **Q4 — Recursion termination / minimum viable accord.** Below some `\|L\|`, does
+  the accord enter a steward-custodied regime rather than a 1-of-1?
+- **Q5 — Constitutional grounding.** This redefines the §9 quorum (standing-roster →
+  live set). It needs an explicit basis in the Constitution / CEG §9 plus a proof
+  that the live quorum *restores* the accord and cannot be used to *weaken* or
+  *seize* it beyond the §8 residual.
 
 ## 11. Relationship to existing modules
 
 - **Reuses** `accord_genesis::build_accord_membership_change` /
-  `verify_accord_membership_change` (the `supersedes` + all its invariants) — the
-  recovery only *replaces the prior-quorum signature requirement* with the
-  proof-of-absence bundle; every other gate (entrenchment, strict-majority,
-  distinct-pubkey, anti-replay) is unchanged.
-- **Reuses** `threshold::verify_founder_quorum` for the steward backstop and the
-  survivor-dissent count.
-- **Reuses** `humanity_accord::Invocation` for the §4.1 fast-path fire.
-- **Does not** touch the closed §9.2.1 invocation vocabulary (no new
-  `InvocationKind`); DECIMATION is a *state* gating the existing `CONSTITUTIONAL`
-  kind, not a new verb.
+  `verify_accord_membership_change` and all its invariants — the live-quorum roster
+  change only swaps the authorizing quorum (standing roster → live set `L`); every
+  other gate (entrenchment, strict-majority, distinct-pubkey, anti-replay) is
+  unchanged.
+- **Reuses** `threshold::verify_founder_quorum` for the live tally and the steward
+  backstop, and `humanity_accord::Invocation` for the fire.
+- **Generalizes** `accord_quorum_from_family`: the threshold is now taken over the
+  live set `L`, not the standing `members` — the standing roster defines *who may
+  participate*, `L` defines *who did*.
+- **Does not** add a new §9.2.1 invocation verb; DECIMATION is a quorum-computation
+  rule over the existing `CONSTITUTIONAL` kind, not a new vocabulary entry.
 
 ## 12. Implementation phases (when grounded + reviewed)
 
 1. **Phase 0 — ratify.** Resolve Q1–Q5; constitutional grounding; threat-model
    sign-off. *No code.*
-2. **Phase 1 — reconstitution (§4.2).** The opposite-quorum recovery objects +
-   verifiers, reusing the membership-change core. Adversarial review (≥ #91/#95
-   rigor). The harder, slower, safety-critical path first.
-3. **Phase 2 — fast invocation (§4.1).** The DECIMATION-state fast fire, gated on
-   Q1's answer.
+2. **Phase 1 — live-quorum tally + roster change.** `accord_proposal` /
+   `accord_participation` / `accord_decision` objects + `tally_live_quorum` +
+   `verify_membership_change_by_live_quorum`, reusing the membership-change core.
+   Adversarial review (≥ #91/#95 rigor).
+3. **Phase 2 — live-quorum fire.** The low-floor `CONSTITUTIONAL` fire over `L`,
+   gated on Q1's floor.
 4. **Phase 3 — server + ceremony.** CIRISServer authoritative recompute (#41/#61),
-   the holder-side recovery ceremony, the steward backstop wiring.
+   the holder participation flow, the steward backstop wiring.
 
 ---
 
-*Authored from the maintainer's "emergency opposite-quorum" proposal + the §2
-first-strike threat model. Prior-art-grounded. This document is the design of
-record for CIRISVerify#98 and supersedes the option sketch in that issue.*
+*Authored from the maintainer's live-quorum correction: proof-of-life **modifies
+the quorum and carries a vote** (it is not a veto), and the system **always leans
+toward firing** (there is no failure-direction asymmetry). Design of record for
+CIRISVerify#98.*


### PR DESCRIPTION
Rewrites FSD-004 to the maintainer's correction of the recovery design.

**Two changes that collapse the design to something tighter and more correct:**

1. **Proof-of-life modifies the quorum + carries a vote — it is not a veto.** There's one mechanism (the **live quorum**); "decimation" is just the case where the live set is small. Each decision is tallied over whoever proves life within a window — absence drops you from the denominator, presence (proof-of-life + vote) re-includes you. A resurfacing holder **rejoins and is counted**, it doesn't unilaterally defeat a proposal. This is Casper-FFG's inactivity-leak made the *standing* rule.

2. **No failure-direction asymmetry — always lean toward firing.** The only terminal error is a *missed* fire; a false fire is recoverable. So every lever minimizes missed-fire: firing leans easiest (down to a lone survivor over the live set), and **reconstitution leans easy too** — a brake on it would only help a suppressor. (Removed the prior draft's "fire easy / reconstitute hard" asymmetry, which was wrong.)

Threshold gradient over the live set `L`: **fire (low floor) ≤ roster-change (strict majority of `L`) ≤ standing-quorum**; steward backstop only when `|L|` is tiny; Enoch-Arden return/reinstatement. Residual shifts to **seize-and-suppress** (bounded by live-majority + steward floor + transparency), not false-fire; coercion/duress is the irreducible open problem (Q3). Reuses the v6.8.0 membership-change core — only the authorizing quorum changes (standing roster → live set).

DRAFT — Q1–Q5 + constitutional grounding gate any build. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)