### PR TITLE
chore(release): v6.8.1 — ship the ml-dsa 0.1.1 seed-zeroize fix (#87)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-build-tool"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-crypto"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "aws-lc-rs",
  "chacha20poly1305",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-keyring"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-manifest-tool"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-verify-core"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "android_system_properties",
  "anyhow",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-verify-ffi"
-version = "6.8.0"
+version = "6.8.1"
 dependencies = [
  "aes-gcm",
  "android_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "6.8.0"
+version = "6.8.1"
 edition = "2021"
 rust-version = "1.86"
 license = "AGPL-3.0-or-later"

--- a/bindings/python/ciris_verify/__init__.py
+++ b/bindings/python/ciris_verify/__init__.py
@@ -127,7 +127,7 @@ def get_library_version() -> str:
     return __version__
 
 
-__version__ = "6.8.0"
+__version__ = "6.8.1"
 __all__ = [
     "CIRISVerify",
     "MockCIRISVerify",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciris-verify"
-version = "6.8.0"
+version = "6.8.1"
 description = "Python bindings for CIRISVerify hardware-rooted license verification"
 readme = "README.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Version bump to release the #87 fix (ml-dsa 0.1.1 outer-SigningKey seed self-zeroize + from_seed_file scrub) already merged via #99. Pure version bump, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)