### PR TITLE
ci: adopt CIRISCache (GHCR cross-repo Rust cache) + pin toolchain (#126)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# CIRISCache (CIRISVerify#126 / CIRISServer#99): the GHCR-backed cross-repo Rust
+# build cache. `restore` is anonymous (public package); `save` (main only)
+# pushes to ghcr.io/cirisai/ciriscache via GITHUB_TOKEN, which needs
+# packages:write. PRs restore but never save, so fork PRs are unaffected.
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   # ==========================================================================
   # Version Consistency Check
@@ -257,28 +265,20 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
-        # CI hardening (v2.1.1+): cache restore is a speedup, not a
-        # correctness gate. A flaky runner / Actions infra hiccup should
-        # downgrade to "build from scratch this run", not abort the job.
-        # Real test/lint/compile failures still fail as before.
+      # CIRISCache (CIRISVerify#126) — GHCR-backed cross-repo Rust cache,
+      # replacing Swatinem/rust-cache (unlimited GHCR storage, survives the
+      # tag-ref boundary, cross-repo-capable). Hardened continue-on-error so a
+      # cache miss/infra hiccup downgrades to a cold build, never failing the
+      # job; real test/lint/compile failures still fail as before.
+      - uses: CIRISAI/CIRISCache/restore@v1
         continue-on-error: true
-        with:
-          # v2.1.4+: exclude ~/.cargo/bin to prevent rustup-init shadow
-          # poisoning. See ci.yml comment block above.
-          cache-bin: false
       - name: Repair toolchain if rustup-init shadow (cache-poison heal)
-        # v2.1.2 detected; v2.1.3 moved after cache restore; v2.1.4 active heal.
-        # macOS runners occasionally cache a `~/.cargo/bin/cargo` that IS the
+        # macOS runners can restore a `~/.cargo/bin/cargo` that IS the
         # rustup-init shim binary. The shim passes `cargo --version` through
         # (any CLI accepts --version), but `cargo build` triggers the shim's
         # argv parser and fails with "unexpected argument 'build' found".
-        # Passive `rustup default stable` doesn't help because the rustup
-        # binary may share the same shim. Active heal: probe via
-        # `cargo build --help` output, nuke ~/.cargo/bin, reinstall toolchain.
-        # Seen on x86_64 + arm64 macOS (v2.1.1 run 25894815013;
-        # v2.1.3 run 25895938932 Test/macos-latest). The cache-bin: false on
-        # the Swatinem step above prevents future poison-then-restore cycles.
+        # Active heal: probe via `cargo build --help`, nuke ~/.cargo/bin,
+        # reinstall the toolchain. Kept defensive across the cache swap.
         # shell: bash forces Git Bash on Windows runners (default is pwsh,
         # which can't parse the if/then/fi syntax below).
         shell: bash
@@ -305,6 +305,13 @@ jobs:
         run: cargo nextest run --all --profile ci
         env:
           PROPTEST_CASES: 64
+
+      # Save the warmed cache (main only; PRs restore but never save).
+      - uses: CIRISAI/CIRISCache/save@v1
+        if: github.ref == 'refs/heads/main'
+        continue-on-error: true
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   # ==========================================================================
   # Feature-gated crypto tests (v4.10.0+, CIRISVerify#58)
@@ -379,17 +386,13 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
-        # CI hardening (v2.1.1+): cache restore is a speedup, not a
-        # correctness gate. A flaky runner / Actions infra hiccup should
-        # downgrade to "build from scratch this run", not abort the job.
-        # Real test/lint/compile failures still fail as before.
+      # CIRISCache (CIRISVerify#126) — per-target key (multiple targets share
+      # the ubuntu host, so the default os-arch key would collide); lock-hash
+      # busts on dependency changes. Hardened continue-on-error.
+      - uses: CIRISAI/CIRISCache/restore@v1
         continue-on-error: true
         with:
-          # v2.1.4+: exclude ~/.cargo/bin to prevent rustup-init shadow
-          # poisoning. See ci.yml comment block above.
-          cache-bin: false
-          key: ${{ matrix.target }}
+          key: ciris-verify-build-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
 
       # Install cross for ARM64 Linux
 
@@ -446,6 +449,13 @@ jobs:
           name: ciris-verify-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/${{ matrix.artifact }}
           if-no-files-found: warn
+
+      # Save the warmed per-target cache (main only).
+      - uses: CIRISAI/CIRISCache/save@v1
+        if: github.ref == 'refs/heads/main'
+        continue-on-error: true
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   # ==========================================================================
   # Build Matrix - Android

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,9 @@
+# Common toolchain pin across the four Rust-compiling CIRIS repos (server /
+# persist / edge / verify) — the rustc version is part of the sccache cache key,
+# so a drift = zero cross-repo cache hits (CIRISVerify#126 / CIRISServer#99).
+# Matches CIRISServer's pin. Stable for all targets except the Win7 Tier-3
+# build-std lane, which the release workflow pins to nightly + rust-src per-job
+# (CIRISVerify#67 pattern); MSRV is enforced separately in CI.
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Adopts CIRISCache (CIRISServer#99) — the GHCR-backed cross-repo Rust build cache — into CIRISVerify CI.

- `rust-toolchain.toml`: pin `stable` + rustfmt/clippy (cross-repo cache-key alignment; CIRISVerify had no pin).
- `ci.yml`: `permissions: packages: write`; swap Swatinem→CIRISCache restore+save in the two heaviest jobs (`test`, `build-native`), restore anonymous + hardened `continue-on-error`, save gated on main; per-target key for the build matrix.

Follow-ups: roll out to the remaining Rust jobs + add the cross-repo *shared* key once the four repos agree the convention.

Refs #126, CIRISServer#99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)