### PR TITLE
ci: adopt the canonical CIRISCache cross-repo key (CIRISServer#99)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,7 +405,12 @@ jobs:
           # `set -e`; flagged back there + on the persist/edge adopters.)
           ver() { { grep -A1 "name = \"$1\"" Cargo.lock | grep -m1 '^version' | sed -E 's/.*"([^"]+)".*/\1/'; } || true; }
           P=$(ver ciris-persist); E=$(ver ciris-edge); V=$(ver ciris-verify-core)
-          KEY="ciris-substrate-v1-${RUNNER_OS,,}-${RUNNER_ARCH,,}-release-rustc${RUSTC}-p${P:-none}-e${E:-none}-v${V:-none}"
+          # `tr` for lowercasing, NOT bash's ${VAR,,} — GitHub macOS runners ship
+          # bash 3.2, where ${,,} is a "bad substitution" fatal error. (Second
+          # latent bug in the #99 snippet, also flagged upstream.)
+          OS=$(printf '%s' "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
+          ARCH=$(printf '%s' "$RUNNER_ARCH" | tr '[:upper:]' '[:lower:]')
+          KEY="ciris-substrate-v1-${OS}-${ARCH}-release-rustc${RUSTC}-p${P:-none}-e${E:-none}-v${V:-none}"
           echo "CIRISCACHE_KEY=${KEY}-${{ matrix.target }}" >> "$GITHUB_ENV"
       - uses: CIRISAI/CIRISCache/restore@v1
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,12 @@ jobs:
         shell: bash
         run: |
           RUSTC=$(rustc -V | awk '{print $2}')
-          ver() { grep -A1 "name = \"$1\"" Cargo.lock | grep -m1 '^version' | sed -E 's/.*"([^"]+)".*/\1/'; }
+          # `|| true` so a crate absent from Cargo.lock (verify has no
+          # ciris-persist / ciris-edge) yields empty instead of grep's exit-1
+          # aborting under GitHub bash's `set -e -o pipefail` — then ${X:-none}
+          # supplies the slot. (The CIRISServer#99 snippet omits this and trips
+          # `set -e`; flagged back there + on the persist/edge adopters.)
+          ver() { { grep -A1 "name = \"$1\"" Cargo.lock | grep -m1 '^version' | sed -E 's/.*"([^"]+)".*/\1/'; } || true; }
           P=$(ver ciris-persist); E=$(ver ciris-edge); V=$(ver ciris-verify-core)
           KEY="ciris-substrate-v1-${RUNNER_OS,,}-${RUNNER_ARCH,,}-release-rustc${RUSTC}-p${P:-none}-e${E:-none}-v${V:-none}"
           echo "CIRISCACHE_KEY=${KEY}-${{ matrix.target }}" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,13 +386,26 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      # CIRISCache (CIRISVerify#126) — per-target key (multiple targets share
-      # the ubuntu host, so the default os-arch key would collide); lock-hash
-      # busts on dependency changes. Hardened continue-on-error.
+      # CIRISCache (CIRISVerify#126) — the **canonical cross-repo key** pinned in
+      # CIRISServer#99, suffixed with the matrix target (verify's build-native is
+      # a cross-compile matrix, so each target is a distinct build that must not
+      # collide on the shared os-arch host). For verify p=e=none (no
+      # ciris-persist / ciris-edge dep), v=ciris-verify-core's resolved version —
+      # so verify keeps its own compiled blob but shares the always-on ~/.cargo
+      # registry blob with the other repos. Derivation is byte-identical across
+      # repos (see #99) so the rustc/version segments line up.
+      - name: Compute CIRISCache key (canonical, CIRISServer#99)
+        shell: bash
+        run: |
+          RUSTC=$(rustc -V | awk '{print $2}')
+          ver() { grep -A1 "name = \"$1\"" Cargo.lock | grep -m1 '^version' | sed -E 's/.*"([^"]+)".*/\1/'; }
+          P=$(ver ciris-persist); E=$(ver ciris-edge); V=$(ver ciris-verify-core)
+          KEY="ciris-substrate-v1-${RUNNER_OS,,}-${RUNNER_ARCH,,}-release-rustc${RUSTC}-p${P:-none}-e${E:-none}-v${V:-none}"
+          echo "CIRISCACHE_KEY=${KEY}-${{ matrix.target }}" >> "$GITHUB_ENV"
       - uses: CIRISAI/CIRISCache/restore@v1
         continue-on-error: true
         with:
-          key: ciris-verify-build-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ env.CIRISCACHE_KEY }}
 
       # Install cross for ARM64 Linux
 
@@ -450,11 +463,12 @@ jobs:
           path: target/${{ matrix.target }}/release/${{ matrix.artifact }}
           if-no-files-found: warn
 
-      # Save the warmed per-target cache (main only).
+      # Save the warmed cache under the canonical key (main only).
       - uses: CIRISAI/CIRISCache/save@v1
         if: github.ref == 'refs/heads/main'
         continue-on-error: true
         with:
+          key: ${{ env.CIRISCACHE_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # ==========================================================================


### PR DESCRIPTION
Adopts the canonical shared-key convention pinned in CIRISServer#99 on verify's release build (`build-native`):
```
ciris-substrate-v1-<os>-<arch>-release-rustc<X.Y.Z>-p<persist>-e<edge>-v<verify>
```
derived byte-identically across repos from the resolved `Cargo.lock`, suffixed with `matrix.target` (build-native is a cross-compile matrix on a shared host). For verify `p=e=none`, `v=ciris-verify-core` — verify keeps its own compiled blob (its build differs) but shares the always-on `~/.cargo` registry blob. The rustc-exact segment lines up via the common `rust-toolchain.toml` pin. Debug (`test`) keeps the per-repo default key per the convention.

Refs #126, CIRISServer#99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)