### PR TITLE
feat(tpm): port seal/unseal into the plugin real backend (dlopen stage 2, #130)

### DIFF
--- a/src/ciris-tpm-plugin/src/backend.rs
+++ b/src/ciris-tpm-plugin/src/backend.rs
@@ -1,0 +1,219 @@
+//! The TPM backend behind the plugin's C ABI.
+//!
+//! Two implementations selected by cfg:
+//! - **real** (`feature = "real"` on glibc-linux / windows): links `tss-esapi`
+//!   and performs the actual TPM 2.0 operations. The seal/unseal logic is a
+//!   faithful port of `ciris_keyring::storage::tpm` (SRK-parented `KeyedHash`
+//!   sealing object), made **pure** — no file I/O; the keyring keeps
+//!   persistence. The sealed blob is `u32_le(private_len) ‖ private ‖ public`,
+//!   opaque to the caller.
+//! - **stub** (everything else, incl. cross-musl): every op reports
+//!   "unavailable" / "not implemented" so the crate builds with no `tss-esapi`.
+
+#[cfg(all(
+    feature = "real",
+    any(all(target_os = "linux", target_env = "gnu"), target_os = "windows")
+))]
+mod imp {
+    use tss_esapi::{
+        attributes::ObjectAttributesBuilder,
+        handles::KeyHandle,
+        interface_types::{
+            algorithm::{HashingAlgorithm, PublicAlgorithm},
+            ecc::EccCurve,
+            key_bits::AesKeyBits,
+            resource_handles::Hierarchy,
+        },
+        structures::{
+            EccPoint, EccScheme, KeyDerivationFunctionScheme, KeyedHashScheme, Private, Public,
+            PublicBuilder, PublicEccParametersBuilder, PublicKeyedHashParameters, SensitiveData,
+            SymmetricDefinitionObject,
+        },
+        tcti_ldr::TctiNameConf,
+        traits::{Marshall, UnMarshall},
+        Context,
+    };
+
+    /// Open an ESYS context over the platform TCTI (Linux device / Windows TBS).
+    /// Ported from `ciris_keyring::platform::tpm::create_context`.
+    fn create_context() -> Result<Context, String> {
+        #[cfg(target_os = "linux")]
+        let tcti = {
+            use std::str::FromStr;
+            use tss_esapi::tcti_ldr::DeviceConfig;
+            let device_path = if std::path::Path::new("/dev/tpmrm0").exists() {
+                "/dev/tpmrm0"
+            } else {
+                "/dev/tpm0"
+            };
+            TctiNameConf::Device(
+                DeviceConfig::from_str(device_path).map_err(|e| format!("device config: {e}"))?,
+            )
+        };
+        #[cfg(target_os = "windows")]
+        let tcti = TctiNameConf::Tbs;
+
+        Context::new(tcti).map_err(|e| format!("TPM context: {e}"))
+    }
+
+    /// The owner-hierarchy ECC P-256 primary (SRK) that parents the sealing
+    /// object. Ported from `ciris_keyring::platform::tpm::get_or_create_primary`.
+    fn get_or_create_primary(context: &mut Context) -> Result<KeyHandle, String> {
+        let object_attributes = ObjectAttributesBuilder::new()
+            .with_fixed_tpm(true)
+            .with_fixed_parent(true)
+            .with_sensitive_data_origin(true)
+            .with_user_with_auth(true)
+            .with_decrypt(true)
+            .with_restricted(true)
+            .build()
+            .map_err(|e| format!("primary attrs: {e}"))?;
+
+        let ecc_params = PublicEccParametersBuilder::new()
+            .with_ecc_scheme(EccScheme::Null)
+            .with_curve(EccCurve::NistP256)
+            .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+            .with_symmetric(SymmetricDefinitionObject::Aes {
+                key_bits: AesKeyBits::Aes128,
+                mode: tss_esapi::interface_types::algorithm::SymmetricMode::Cfb,
+            })
+            .with_is_signing_key(false)
+            .with_is_decryption_key(true)
+            .with_restricted(true)
+            .build()
+            .map_err(|e| format!("primary ecc params: {e}"))?;
+
+        let primary_public = PublicBuilder::new()
+            .with_public_algorithm(PublicAlgorithm::Ecc)
+            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+            .with_object_attributes(object_attributes)
+            .with_ecc_parameters(ecc_params)
+            .with_ecc_unique_identifier(EccPoint::default())
+            .build()
+            .map_err(|e| format!("primary public: {e}"))?;
+
+        let result = context
+            .execute_with_nullauth_session(|ctx| {
+                ctx.create_primary(
+                    Hierarchy::Owner,
+                    primary_public.clone(),
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+            })
+            .map_err(|e| format!("TPM2_CreatePrimary: {e}"))?;
+        Ok(result.key_handle)
+    }
+
+    pub fn available() -> i32 {
+        match create_context() {
+            Ok(_) => 1,
+            Err(e) => {
+                tracing::debug!("ciris-tpm-plugin: no usable TPM ({e})");
+                0
+            },
+        }
+    }
+
+    /// Seal `input` under the SRK → `u32_le(private_len) ‖ private ‖ public`.
+    /// Pure: no persistence (the keyring stores the returned blob).
+    pub fn seal(input: &[u8]) -> Result<Vec<u8>, String> {
+        let mut context = create_context()?;
+        let primary = get_or_create_primary(&mut context)?;
+
+        let object_attributes = ObjectAttributesBuilder::new()
+            .with_fixed_tpm(true)
+            .with_fixed_parent(true)
+            .with_user_with_auth(true)
+            .build()
+            .map_err(|e| format!("seal attrs: {e}"))?;
+
+        let public = PublicBuilder::new()
+            .with_public_algorithm(PublicAlgorithm::KeyedHash)
+            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+            .with_object_attributes(object_attributes)
+            .with_keyed_hash_parameters(PublicKeyedHashParameters::new(KeyedHashScheme::Null))
+            .with_keyed_hash_unique_identifier(Default::default())
+            .build()
+            .map_err(|e| format!("seal public: {e}"))?;
+
+        let sensitive =
+            SensitiveData::try_from(input.to_vec()).map_err(|e| format!("seal sensitive: {e}"))?;
+
+        let create_result = context
+            .execute_with_nullauth_session(|ctx| {
+                ctx.create(
+                    primary,
+                    public.clone(),
+                    None,
+                    Some(sensitive.clone()),
+                    None,
+                    None,
+                )
+            })
+            .map_err(|e| format!("TPM2_Create (seal): {e}"))?;
+
+        let private_blob = create_result.out_private.to_vec();
+        let public_blob = create_result
+            .out_public
+            .marshall()
+            .map_err(|e| format!("marshall sealed public: {e}"))?;
+        let _ = context.flush_context(primary.into());
+
+        let plen = u32::try_from(private_blob.len()).map_err(|_| "private blob too large")?;
+        let mut blob = Vec::with_capacity(4 + private_blob.len() + public_blob.len());
+        blob.extend_from_slice(&plen.to_le_bytes());
+        blob.extend_from_slice(&private_blob);
+        blob.extend_from_slice(&public_blob);
+        Ok(blob)
+    }
+
+    /// Unseal a blob produced by [`seal`] → the original plaintext.
+    pub fn unseal(blob: &[u8]) -> Result<Vec<u8>, String> {
+        if blob.len() < 4 {
+            return Err("sealed blob too short".into());
+        }
+        let plen = u32::from_le_bytes([blob[0], blob[1], blob[2], blob[3]]) as usize;
+        if blob.len() < 4 + plen {
+            return Err("sealed blob truncated".into());
+        }
+        let private = Private::try_from(blob[4..4 + plen].to_vec())
+            .map_err(|e| format!("sealed private: {e}"))?;
+        let public =
+            Public::unmarshall(&blob[4 + plen..]).map_err(|e| format!("sealed public: {e}"))?;
+
+        let mut context = create_context()?;
+        let primary = get_or_create_primary(&mut context)?;
+
+        let loaded = context
+            .execute_with_nullauth_session(|ctx| ctx.load(primary, private, public))
+            .map_err(|e| format!("TPM2_Load (wrong TPM?): {e}"))?;
+        let unsealed = context
+            .execute_with_nullauth_session(|ctx| ctx.unseal(loaded.into()))
+            .map_err(|e| format!("TPM2_Unseal: {e}"))?;
+        let _ = context.flush_context(loaded.into());
+        let _ = context.flush_context(primary.into());
+
+        Ok(unsealed.value().to_vec())
+    }
+}
+
+#[cfg(not(all(
+    feature = "real",
+    any(all(target_os = "linux", target_env = "gnu"), target_os = "windows")
+)))]
+mod imp {
+    pub fn available() -> i32 {
+        super::super::CIRIS_TPM_UNAVAILABLE
+    }
+    pub fn seal(_input: &[u8]) -> Result<Vec<u8>, String> {
+        Err("ciris-tpm-plugin built without the `real` backend".to_string())
+    }
+    pub fn unseal(_blob: &[u8]) -> Result<Vec<u8>, String> {
+        Err("ciris-tpm-plugin built without the `real` backend".to_string())
+    }
+}
+
+pub use imp::{available, seal, unseal};

--- a/src/ciris-tpm-plugin/src/lib.rs
+++ b/src/ciris-tpm-plugin/src/lib.rs
@@ -21,11 +21,14 @@
 //!
 //! # Status — staged
 //!
-//! **Stage 1 (this):** the C ABI surface + the `available`/version vertical
-//! slice. The seal / unseal / sign / quote operations are declared and return
-//! [`CIRIS_TPM_NOT_IMPLEMENTED`] until staged in (they port the existing
-//! `ciris_keyring::platform::tpm` / `storage::tpm` logic into the plugin behind
-//! this ABI). The keyring `dlopen` client is a later stage.
+//! - **Stage 1:** the C ABI surface + ABI version + the `available` detection
+//!   vertical slice.
+//! - **Stage 2 (this):** `seal` / `unseal` implemented in the `real` backend —
+//!   a pure (no-file-I/O) port of `ciris_keyring::storage::tpm`'s SRK-parented
+//!   `KeyedHash` sealing (see `backend.rs`). The sealed blob is opaque.
+//! - **Later:** `sign` / `quote` (the native `TpmSigner` path — they will use
+//!   [`CIRIS_TPM_NOT_IMPLEMENTED`] until staged in), then the keyring `dlopen`
+//!   client, then the flip that removes `tss-esapi` from the keyring entirely.
 //!
 //! # ABI discipline
 //!
@@ -78,68 +81,81 @@ pub unsafe extern "C" fn ciris_tpm_free(ptr: *mut u8, len: usize) {
     }
 }
 
-// ── Staged operations (declared; implemented in later stages) ─────────────
-// Each ports the corresponding ciris_keyring::platform::tpm / storage::tpm op
-// into the plugin behind this ABI: seal/unseal (master-key blob under the SRK),
-// sign (slot key), quote (attestation). Until then they fail closed.
+/// Allocate `bytes` on the plugin heap and hand ownership out via the
+/// out-pointers (freed by [`ciris_tpm_free`]).
+unsafe fn emit(bytes: Vec<u8>, out: *mut *mut u8, out_len: *mut usize) {
+    let mut boxed = bytes.into_boxed_slice();
+    *out_len = boxed.len();
+    *out = boxed.as_mut_ptr();
+    std::mem::forget(boxed);
+}
 
-/// Seal `input` under the TPM SRK → sealed blob in `out`/`out_len`. (Stage 2.)
+/// Seal `input` under the TPM SRK → sealed blob in `out`/`out_len` (stage 2).
+///
+/// The blob is opaque (`u32_le(private_len) ‖ private ‖ public`); only the same
+/// TPM can unseal it. Returns [`CIRIS_TPM_OK`], [`CIRIS_TPM_UNAVAILABLE`] (no
+/// real backend), or [`CIRIS_TPM_ERROR`] (a TPM fault).
 ///
 /// # Safety
-/// Pointers must be valid; `out`/`out_len` receive a `ciris_tpm_free`-able buffer.
+/// `input` valid for `input_len` (or null iff `input_len == 0`); `out`/`out_len`
+/// valid. The returned buffer is freed via [`ciris_tpm_free`].
 #[no_mangle]
 pub unsafe extern "C" fn ciris_tpm_seal(
-    _input: *const u8,
-    _input_len: usize,
-    _out: *mut *mut u8,
-    _out_len: *mut usize,
+    input: *const u8,
+    input_len: usize,
+    out: *mut *mut u8,
+    out_len: *mut usize,
 ) -> i32 {
-    CIRIS_TPM_NOT_IMPLEMENTED
+    if out.is_null() || out_len.is_null() || (input.is_null() && input_len != 0) {
+        return CIRIS_TPM_ERROR;
+    }
+    let data = if input_len == 0 {
+        &[][..]
+    } else {
+        std::slice::from_raw_parts(input, input_len)
+    };
+    match backend::seal(data) {
+        Ok(blob) => {
+            emit(blob, out, out_len);
+            CIRIS_TPM_OK
+        },
+        Err(e) => {
+            tracing::error!("ciris_tpm_seal: {e}");
+            CIRIS_TPM_ERROR
+        },
+    }
 }
 
-/// Unseal a blob produced by [`ciris_tpm_seal`]. (Stage 2.)
+/// Unseal a blob produced by [`ciris_tpm_seal`] → plaintext in `out`/`out_len`.
 ///
 /// # Safety
-/// Pointers must be valid; `out`/`out_len` receive a `ciris_tpm_free`-able buffer.
+/// `sealed` valid for `sealed_len`; `out`/`out_len` valid. The returned buffer
+/// is freed via [`ciris_tpm_free`].
 #[no_mangle]
 pub unsafe extern "C" fn ciris_tpm_unseal(
-    _sealed: *const u8,
-    _sealed_len: usize,
-    _out: *mut *mut u8,
-    _out_len: *mut usize,
+    sealed: *const u8,
+    sealed_len: usize,
+    out: *mut *mut u8,
+    out_len: *mut usize,
 ) -> i32 {
-    CIRIS_TPM_NOT_IMPLEMENTED
-}
-
-/// The real (tss-esapi) backend, gated to where it can link; otherwise a stub
-/// that honestly reports "unavailable".
-mod backend {
-    #[cfg(all(
-        feature = "real",
-        any(all(target_os = "linux", target_env = "gnu"), target_os = "windows")
-    ))]
-    pub fn available() -> i32 {
-        // A usable TPM = an ESYS context opens over the default TCTI.
-        match tss_esapi::Context::new(
-            tss_esapi::TctiNameConf::from_environment_variable()
-                .unwrap_or(tss_esapi::TctiNameConf::Tabrmd(Default::default())),
-        ) {
-            Ok(_) => 1,
-            Err(e) => {
-                tracing::debug!("ciris-tpm-plugin: no usable TPM ({e})");
-                0
-            },
-        }
+    if sealed.is_null() || out.is_null() || out_len.is_null() {
+        return CIRIS_TPM_ERROR;
     }
-
-    #[cfg(not(all(
-        feature = "real",
-        any(all(target_os = "linux", target_env = "gnu"), target_os = "windows")
-    )))]
-    pub fn available() -> i32 {
-        super::CIRIS_TPM_UNAVAILABLE
+    let blob = std::slice::from_raw_parts(sealed, sealed_len);
+    match backend::unseal(blob) {
+        Ok(plain) => {
+            emit(plain, out, out_len);
+            CIRIS_TPM_OK
+        },
+        Err(e) => {
+            tracing::error!("ciris_tpm_unseal: {e}");
+            CIRIS_TPM_ERROR
+        },
     }
 }
+
+/// The TPM backend — real (`tss-esapi`, gnu/win) or stub. See `backend.rs`.
+mod backend;
 
 #[cfg(test)]
 mod tests {
@@ -151,11 +167,27 @@ mod tests {
     }
 
     #[test]
-    fn staged_ops_fail_closed_until_implemented() {
+    fn seal_fails_closed_without_a_tpm() {
+        // No test environment has a TPM (stub build: no backend; real build: no
+        // device), so seal must never report success here — it fails closed.
         let mut out: *mut u8 = std::ptr::null_mut();
         let mut out_len: usize = 0;
-        let rc = unsafe { ciris_tpm_seal(std::ptr::null(), 0, &mut out, &mut out_len) };
-        assert_eq!(rc, CIRIS_TPM_NOT_IMPLEMENTED);
+        let data = [1u8, 2, 3];
+        let rc = unsafe { ciris_tpm_seal(data.as_ptr(), data.len(), &mut out, &mut out_len) };
+        assert_ne!(rc, CIRIS_TPM_OK, "seal must fail closed with no usable TPM");
+    }
+
+    #[test]
+    fn null_pointers_are_rejected_not_dereferenced() {
+        let rc = unsafe {
+            ciris_tpm_seal(
+                std::ptr::null(),
+                0,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, CIRIS_TPM_ERROR);
     }
 
     #[test]


### PR DESCRIPTION
**Stage 2** of the runtime-loaded TPM backend (umbrella #130, after stage 1 #132).

The plugin's `ciris_tpm_seal` / `ciris_tpm_unseal` C ABI now do **real TPM 2.0 sealing** via `tss-esapi` (the `real` backend, gnu/win) — a faithful **pure** port of `ciris_keyring::storage::tpm`:
- `create_context` (Linux device / Windows TBS) + `get_or_create_primary` (owner-hierarchy ECC P-256 SRK) ported into `backend.rs`.
- **seal**: a `KeyedHash` null-scheme sealing object under the SRK → opaque blob `u32_le(private_len) ‖ private ‖ public`. **No file I/O** — the keyring keeps persistence, so the ABI is storage-agnostic.
- **unseal**: deserialize `{private, public}`, `TPM2_Load` under the SRK, `TPM2_Unseal`.
- `emit()` hands results out on the plugin heap (freed via `ciris_tpm_free`).
- Fail-closed: null-pointer guard; no TPM → `CIRIS_TPM_ERROR`; stub build (no `tss-esapi`, incl. cross-musl) → unavailable.

The real backend **typechecks against tss-esapi 7.7**; the stub builds everywhere. clippy clean both paths; 4 ABI tests pass. Not yet wired into the keyring (stage 3). No version bump.

NB: seal/unseal can't be unit-tested without a TPM (same as the keyring's own — they're integration-tested where hardware exists); correctness here is the faithful port + the compile against the live tss-esapi API.

Refs #130, #125, #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)