### PR TITLE
fix(keyring): v7.5.1 — sealed signers must not silently mint on re-open (#134)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-build-tool"
-version = "7.5.0"
+version = "7.5.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-crypto"
-version = "7.5.0"
+version = "7.5.1"
 dependencies = [
  "aws-lc-rs",
  "chacha20poly1305",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-keyring"
-version = "7.5.0"
+version = "7.5.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-manifest-tool"
-version = "7.5.0"
+version = "7.5.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-tpm-plugin"
-version = "7.5.0"
+version = "7.5.1"
 dependencies = [
  "tracing",
  "tss-esapi",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-verify-core"
-version = "7.5.0"
+version = "7.5.1"
 dependencies = [
  "android_system_properties",
  "anyhow",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-verify-ffi"
-version = "7.5.0"
+version = "7.5.1"
 dependencies = [
  "aes-gcm",
  "android_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "7.5.0"
+version = "7.5.1"
 edition = "2021"
 rust-version = "1.86"
 license = "AGPL-3.0-or-later"

--- a/bindings/python/ciris_verify/__init__.py
+++ b/bindings/python/ciris_verify/__init__.py
@@ -129,7 +129,7 @@ def get_library_version() -> str:
     return __version__
 
 
-__version__ = "7.5.0"
+__version__ = "7.5.1"
 __all__ = [
     "CIRISVerify",
     "MockCIRISVerify",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciris-verify"
-version = "7.5.0"
+version = "7.5.1"
 description = "Python bindings for CIRISVerify hardware-rooted license verification"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/src/ciris-keyring/src/sealed_ed25519.rs
+++ b/src/ciris-keyring/src/sealed_ed25519.rs
@@ -27,7 +27,7 @@
 //!   32-byte seed **byte-identically** (the software-Ed25519 → TPM migration:
 //!   the destination hash / `key_id` is unchanged, so announces and routing
 //!   survive). Only seals if no sealed seed is present yet — idempotent.
-//! - **Generate** — [`SealedEd25519Signer::open`] on a fresh `seed_dir`
+//! - **Generate** — [`SealedEd25519Signer::open_or_create`] (`None`) on a fresh `seed_dir`
 //!   generates a 32-byte seed from the OS CSPRNG and seals it.
 //!
 //! Same AV-17 carve-out as #68: hardware-backed at rest; the seed is in
@@ -72,21 +72,14 @@ impl SealedEd25519Signer {
     ) -> Result<Self, KeyringError> {
         let alias = alias.into();
         let seed_dir = seed_dir.into();
-        let storage = create_platform_storage(&alias, &seed_dir)?;
 
-        let mut seed: [u8; SEED_LEN] = match storage.load(SEED_KEY_ID) {
-            // Already sealed → adopt verbatim (key_id preserved).
-            Ok(raw) => raw
-                .as_slice()
-                .try_into()
-                .map_err(|_| KeyringError::InvalidKey {
-                    reason: format!(
-                        "sealed Ed25519 seed is {} bytes, expected {SEED_LEN}",
-                        raw.len()
-                    ),
-                })?,
-            // Not yet sealed → adopt the provided seed, or generate one.
+        // Deliberate first-seal: re-open if present, else seal. Re-open paths
+        // must NOT come through here with `None` (that would mint a fresh key
+        // on a missing seed — the #134 hazard); they use `open_existing`.
+        match Self::open_existing(alias.clone(), seed_dir.clone()) {
+            Ok(signer) => Ok(signer),
             Err(KeyringError::KeyNotFound { .. }) => {
+                let storage = create_platform_storage(&alias, &seed_dir)?;
                 let mut s = [0u8; SEED_LEN];
                 match adopt_seed {
                     Some(existing) => s.copy_from_slice(existing),
@@ -96,10 +89,44 @@ impl SealedEd25519Signer {
                     },
                 }
                 storage.store(SEED_KEY_ID, &s)?;
-                s
+                let inner = Ed25519SoftwareSigner::from_bytes(&s, alias.clone())?;
+                s.iter_mut().for_each(|b| *b = 0);
+                core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+                Ok(Self {
+                    inner,
+                    storage,
+                    alias,
+                    seed_dir,
+                })
             },
-            Err(e) => return Err(e),
-        };
+            Err(e) => Err(e),
+        }
+    }
+
+    /// **Re-open** an existing sealed Ed25519 signer — **load-only**. Errors
+    /// [`KeyringError::KeyNotFound`] if no sealed seed is present at `seed_dir`.
+    /// Re-opening an identity must never mint a fresh seed (it would swap the
+    /// key for an unverifiable one; CIRISVerify#134). The deliberate first-seal
+    /// is [`Self::adopt`] / [`Self::open_or_create`].
+    pub fn open_existing(
+        alias: impl Into<String>,
+        seed_dir: impl Into<PathBuf>,
+    ) -> Result<Self, KeyringError> {
+        let alias = alias.into();
+        let seed_dir = seed_dir.into();
+        let storage = create_platform_storage(&alias, &seed_dir)?;
+
+        // `KeyNotFound` propagates — re-open does NOT fabricate a seed (#134).
+        let raw = storage.load(SEED_KEY_ID)?;
+        let mut seed: [u8; SEED_LEN] =
+            raw.as_slice()
+                .try_into()
+                .map_err(|_| KeyringError::InvalidKey {
+                    reason: format!(
+                        "sealed Ed25519 seed is {} bytes, expected {SEED_LEN}",
+                        raw.len()
+                    ),
+                })?;
 
         let inner = Ed25519SoftwareSigner::from_bytes(&seed, alias.clone())?;
         // Scrub the local seed copy; the live key now lives in `inner`, the
@@ -116,12 +143,15 @@ impl SealedEd25519Signer {
         })
     }
 
-    /// Open at `seed_dir`: adopt the sealed seed, or generate+seal a fresh one.
+    /// **Re-open** an existing sealed signer (load-only). Errors
+    /// [`KeyringError::KeyNotFound`] if absent — re-opening never mints
+    /// (CIRISVerify#134). Use [`Self::adopt`] / [`Self::open_or_create`] for the
+    /// deliberate first-seal.
     pub fn open(
         alias: impl Into<String>,
         seed_dir: impl Into<PathBuf>,
     ) -> Result<Self, KeyringError> {
-        Self::open_or_create(alias, seed_dir, None)
+        Self::open_existing(alias, seed_dir)
     }
 
     /// Adopt an existing 32-byte Ed25519 `seed` byte-identically (the
@@ -139,9 +169,11 @@ impl SealedEd25519Signer {
 
 /// Best-tier sealed **Ed25519** federation signer (CIRISVerify#70) — the
 /// Ed25519 counterpart to `get_platform_signer` (which yields TPM-native
-/// ECDSA). Auto-detects the hardware tier with software fallback; generates on
-/// first use and adopts a previously-sealed seed verbatim. Returns a
-/// `Box<dyn HardwareSigner>` whose `public_key()` is the 32-byte Ed25519 key,
+/// ECDSA). Auto-detects the hardware tier with software fallback. **Re-opens** a
+/// previously-sealed seed; errors `KeyNotFound` if absent — it never mints, so a
+/// missing seed surfaces instead of silently swapping the identity (#134;
+/// deliberate first-seal is `SealedEd25519Signer::adopt` / `open_or_create`).
+/// Returns a `Box<dyn HardwareSigner>` whose `public_key()` is the 32-byte Ed25519 key,
 /// ready for `ciris_persist::Engine::with_hardware_signer` /
 /// `ciris_edge::LocalSigner`.
 pub fn get_platform_ed25519_signer(
@@ -251,7 +283,8 @@ mod tests {
     #[tokio::test]
     async fn pubkey_is_32_byte_ed25519_and_signs() {
         let dir = tmpdir();
-        let signer = get_platform_ed25519_signer("fed-key", &dir).unwrap();
+        // Mint (deliberate first-seal) — re-open is load-only now (#134).
+        let signer = SealedEd25519Signer::open_or_create("fed-key", &dir, None).unwrap();
         assert_eq!(signer.algorithm(), ClassicalAlgorithm::Ed25519);
         let pk = signer.public_key().await.unwrap();
         assert_eq!(pk.len(), 32, "federation pubkey must be 32-byte Ed25519");
@@ -284,10 +317,11 @@ mod tests {
     async fn sealed_seed_persists_and_readopt_is_idempotent() {
         let dir = tmpdir();
         let pk1 = {
-            let s = SealedEd25519Signer::open("fed-key", &dir).unwrap();
+            // Mint (deliberate first-seal).
+            let s = SealedEd25519Signer::open_or_create("fed-key", &dir, None).unwrap();
             s.public_key().await.unwrap()
         };
-        // Reopen → same key.
+        // Reopen (load-only) → same key.
         let pk2 = {
             let s = SealedEd25519Signer::open("fed-key", &dir).unwrap();
             s.public_key().await.unwrap()
@@ -315,7 +349,7 @@ mod tests {
         // Linux release wheel) it lands on the Hardware arm. Either is honest;
         // a disagreement is the bug.
         let dir = tmpdir();
-        let signer = get_platform_ed25519_signer("fed-key", &dir).unwrap();
+        let signer = SealedEd25519Signer::open_or_create("fed-key", &dir, None).unwrap();
         let tier_is_software = signer.hardware_type() == HardwareType::SoftwareOnly;
         let descriptor_is_software = matches!(
             signer.storage_descriptor(),
@@ -331,7 +365,7 @@ mod tests {
     #[tokio::test]
     async fn delete_then_key_absent() {
         let dir = tmpdir();
-        let signer = get_platform_ed25519_signer("fed-key", &dir).unwrap();
+        let signer = SealedEd25519Signer::open_or_create("fed-key", &dir, None).unwrap();
         assert!(signer.key_exists("fed-key").await.unwrap());
         signer.delete_key("fed-key").await.unwrap();
         assert!(!signer.key_exists("fed-key").await.unwrap());
@@ -342,9 +376,31 @@ mod tests {
     async fn holds_as_arc_dyn_hardware_signer() {
         // The CIRISServer consumption: Arc<dyn HardwareSigner> for persist/edge.
         let dir = tmpdir();
+        // Mint first; the factory re-opens (load-only) now (#134).
+        SealedEd25519Signer::open_or_create("fed-key", &dir, None).unwrap();
         let signer: std::sync::Arc<dyn HardwareSigner> =
             std::sync::Arc::from(get_platform_ed25519_signer("fed-key", &dir).unwrap());
         assert_eq!(signer.public_key().await.unwrap().len(), 32);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #134 regression: re-opening a non-existent sealed seed must FAIL, never
+    /// silently mint a fresh key (which would swap the federation identity).
+    #[tokio::test]
+    async fn open_fails_loud_on_missing_seed() {
+        let dir = tmpdir();
+        assert!(matches!(
+            SealedEd25519Signer::open("fed-key", &dir),
+            Err(KeyringError::KeyNotFound { .. })
+        ));
+        assert!(matches!(
+            SealedEd25519Signer::open_existing("fed-key", &dir),
+            Err(KeyringError::KeyNotFound { .. })
+        ));
+        assert!(
+            get_platform_ed25519_signer("fed-key", &dir).is_err(),
+            "the factory re-opens — it must not mint on a missing seed"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/ciris-keyring/src/sealed_mldsa65.rs
+++ b/src/ciris-keyring/src/sealed_mldsa65.rs
@@ -32,7 +32,7 @@
 //!   32-byte seed **byte-identically** (the software→sealed migration: the
 //!   ML-DSA-65 pubkey and therefore the hybrid `key_id` are preserved).
 //!   Idempotent — won't clobber an already-sealed key.
-//! - **Generate** — [`SealedMlDsa65Signer::open`] on a fresh `seed_dir`
+//! - **Generate** — [`SealedMlDsa65Signer::open_or_create`] (`None`) on a fresh `seed_dir`
 //!   generates a 32-byte seed from the OS CSPRNG and seals it.
 
 use std::path::PathBuf;
@@ -59,43 +59,32 @@ pub struct SealedMlDsa65Signer {
 }
 
 impl SealedMlDsa65Signer {
-    /// Open the sealed ML-DSA-65 signer at `seed_dir`. A sealed seed already
-    /// present is adopted verbatim; otherwise, if `adopt_seed` is `Some`, that
-    /// 32-byte seed is sealed byte-identically; otherwise a fresh seed is
-    /// generated from the OS CSPRNG and sealed.
-    pub fn open_or_create(
+    /// **Re-open** an existing sealed ML-DSA-65 signer — **load-only**. Errors
+    /// [`KeyringError::KeyNotFound`] if no sealed seed is present at `seed_dir`.
+    ///
+    /// Re-opening an identity must **never** mint a fresh seed: doing so swaps
+    /// the PQC half of the hybrid federation key for an unverifiable one and
+    /// silently destroys the original (CIRISVerify#134, the #275 hazard class).
+    /// The deliberate first-seal is [`Self::adopt`] / [`Self::open_or_create`].
+    pub fn open_existing(
         alias: impl Into<String>,
         seed_dir: impl Into<PathBuf>,
-        adopt_seed: Option<&[u8; SEED_LEN]>,
     ) -> Result<Self, KeyringError> {
         let alias = alias.into();
         let seed_dir = seed_dir.into();
         let storage = create_platform_storage(&alias, &seed_dir)?;
 
-        let mut seed: [u8; SEED_LEN] = match storage.load(SEED_KEY_ID) {
-            Ok(raw) => raw
-                .as_slice()
+        // `KeyNotFound` propagates — re-open does NOT fabricate a seed (#134).
+        let raw = storage.load(SEED_KEY_ID)?;
+        let mut seed: [u8; SEED_LEN] =
+            raw.as_slice()
                 .try_into()
                 .map_err(|_| KeyringError::InvalidKey {
                     reason: format!(
                         "sealed ML-DSA-65 seed is {} bytes, expected {SEED_LEN}",
                         raw.len()
                     ),
-                })?,
-            Err(KeyringError::KeyNotFound { .. }) => {
-                let mut s = [0u8; SEED_LEN];
-                match adopt_seed {
-                    Some(existing) => s.copy_from_slice(existing),
-                    None => {
-                        use rand_core::{OsRng, RngCore};
-                        OsRng.fill_bytes(&mut s);
-                    },
-                }
-                storage.store(SEED_KEY_ID, &s)?;
-                s
-            },
-            Err(e) => return Err(e),
-        };
+                })?;
 
         let inner = MlDsa65SoftwareSigner::from_seed_bytes(&seed, alias.clone())?;
         // Scrub the local seed copy; the durable copy is sealed in `storage`.
@@ -110,12 +99,57 @@ impl SealedMlDsa65Signer {
         })
     }
 
-    /// Open at `seed_dir`: adopt the sealed seed, or generate+seal a fresh one.
+    /// **Deliberate first-seal.** Re-opens a sealed seed if present; otherwise
+    /// seals one — `adopt_seed = Some` seals that exact 32-byte seed (the
+    /// software→hardware migration), `None` mints a fresh OS-CSPRNG seed.
+    ///
+    /// Call this **only on a deliberate mint** (identity creation). Re-open
+    /// paths (node startup) must use [`Self::open`] / [`Self::open_existing`],
+    /// which fail loud rather than fabricate a key (CIRISVerify#134).
+    pub fn open_or_create(
+        alias: impl Into<String>,
+        seed_dir: impl Into<PathBuf>,
+        adopt_seed: Option<&[u8; SEED_LEN]>,
+    ) -> Result<Self, KeyringError> {
+        let alias = alias.into();
+        let seed_dir = seed_dir.into();
+
+        match Self::open_existing(alias.clone(), seed_dir.clone()) {
+            Ok(signer) => Ok(signer),
+            Err(KeyringError::KeyNotFound { .. }) => {
+                let storage = create_platform_storage(&alias, &seed_dir)?;
+                let mut s = [0u8; SEED_LEN];
+                match adopt_seed {
+                    Some(existing) => s.copy_from_slice(existing),
+                    None => {
+                        use rand_core::{OsRng, RngCore};
+                        OsRng.fill_bytes(&mut s);
+                    },
+                }
+                storage.store(SEED_KEY_ID, &s)?;
+                let inner = MlDsa65SoftwareSigner::from_seed_bytes(&s, alias.clone())?;
+                s.iter_mut().for_each(|b| *b = 0);
+                core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+                Ok(Self {
+                    inner,
+                    storage,
+                    alias,
+                    seed_dir,
+                })
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    /// **Re-open** an existing sealed signer (load-only). Errors
+    /// [`KeyringError::KeyNotFound`] if absent — re-opening never mints
+    /// (CIRISVerify#134). Use [`Self::adopt`] / [`Self::open_or_create`] for the
+    /// deliberate first-seal.
     pub fn open(
         alias: impl Into<String>,
         seed_dir: impl Into<PathBuf>,
     ) -> Result<Self, KeyringError> {
-        Self::open_or_create(alias, seed_dir, None)
+        Self::open_existing(alias, seed_dir)
     }
 
     /// Adopt an existing 32-byte ML-DSA-65 `seed` byte-identically (the
@@ -131,10 +165,12 @@ impl SealedMlDsa65Signer {
 }
 
 /// Best-tier sealed **ML-DSA-65** federation signer (CIRISVerify#70 PQC analog)
-/// — the post-quantum counterpart to `get_platform_ed25519_signer`. Generates
-/// on first use, adopts a previously-sealed seed verbatim, returns a
-/// `Box<dyn PqcSigner>` whose `public_key()` is the ML-DSA-65 pubkey. Pair it
-/// with `get_platform_ed25519_signer` to give both halves of the hybrid
+/// — the post-quantum counterpart to `get_platform_ed25519_signer`. **Re-opens**
+/// a previously-sealed seed (errors `KeyNotFound` if absent — it never mints, so
+/// a missing seed surfaces instead of silently swapping the PQC identity, #134;
+/// deliberate first-seal is `SealedMlDsa65Signer::adopt` / `open_or_create`),
+/// returns a `Box<dyn PqcSigner>` whose `public_key()` is the ML-DSA-65 pubkey.
+/// Pair it with `get_platform_ed25519_signer` to give both halves of the hybrid
 /// federation key hardware-backed-at-rest custody.
 pub fn get_platform_sealed_mldsa65_signer(
     alias: &str,
@@ -206,7 +242,8 @@ mod tests {
     #[tokio::test]
     async fn pubkey_is_mldsa65_and_signs_verifiably() {
         let dir = tmpdir();
-        let signer = get_platform_sealed_mldsa65_signer("fed-pqc", &dir).unwrap();
+        // Mint (deliberate first-seal) — re-open is load-only now (#134).
+        let signer = SealedMlDsa65Signer::open_or_create("fed-pqc", &dir, None).unwrap();
         assert_eq!(signer.algorithm(), PqcAlgorithm::MlDsa65);
         let pk = signer.public_key().await.unwrap();
         assert_eq!(pk.len(), 1952, "ML-DSA-65 pubkey length");
@@ -236,12 +273,12 @@ mod tests {
     #[tokio::test]
     async fn sealed_seed_persists_and_readopt_is_idempotent() {
         let dir = tmpdir();
-        let pk1 = SealedMlDsa65Signer::open("fed-pqc", &dir)
+        let pk1 = SealedMlDsa65Signer::open_or_create("fed-pqc", &dir, None)
             .unwrap()
             .public_key()
             .await
             .unwrap();
-        // Reopen → same key.
+        // Reopen (load-only) → same key.
         let pk2 = SealedMlDsa65Signer::open("fed-pqc", &dir)
             .unwrap()
             .public_key()
@@ -268,7 +305,7 @@ mod tests {
         // the sealed seed is genuinely hardware-backed and both move to the
         // Hardware arm. A disagreement between the two is the bug.
         let dir = tmpdir();
-        let signer = get_platform_sealed_mldsa65_signer("fed-pqc", &dir).unwrap();
+        let signer = SealedMlDsa65Signer::open_or_create("fed-pqc", &dir, None).unwrap();
         let tier_is_software = signer.hardware_type() == HardwareType::SoftwareOnly;
         let descriptor_is_software = matches!(
             signer.storage_descriptor(),
@@ -284,9 +321,32 @@ mod tests {
     #[tokio::test]
     async fn holds_as_arc_dyn_pqc_signer() {
         let dir = tmpdir();
+        // Mint first; the factory re-opens (load-only) now (#134).
+        SealedMlDsa65Signer::open_or_create("fed-pqc", &dir, None).unwrap();
         let signer: std::sync::Arc<dyn PqcSigner> =
             std::sync::Arc::from(get_platform_sealed_mldsa65_signer("fed-pqc", &dir).unwrap());
         assert_eq!(signer.algorithm(), PqcAlgorithm::MlDsa65);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #134 regression: re-opening a non-existent sealed seed must FAIL, never
+    /// silently mint a fresh ML-DSA key (which would destroy the PQC half of
+    /// the hybrid federation identity, leaving an unverifiable signer).
+    #[tokio::test]
+    async fn open_fails_loud_on_missing_seed() {
+        let dir = tmpdir();
+        assert!(matches!(
+            SealedMlDsa65Signer::open("fed-pqc", &dir),
+            Err(KeyringError::KeyNotFound { .. })
+        ));
+        assert!(matches!(
+            SealedMlDsa65Signer::open_existing("fed-pqc", &dir),
+            Err(KeyringError::KeyNotFound { .. })
+        ));
+        assert!(
+            get_platform_sealed_mldsa65_signer("fed-pqc", &dir).is_err(),
+            "the factory re-opens — it must not mint on a missing seed"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/ciris-keyring/src/usb_wrapped_mldsa65.rs
+++ b/src/ciris-keyring/src/usb_wrapped_mldsa65.rs
@@ -437,7 +437,8 @@ mod tests {
     // A deterministic Ed25519 HardwareSigner standing in for the YubiKey
     // (Ed25519 is RFC-8032 deterministic — exactly the property the wrap needs).
     fn yubikey(alias: &str) -> SealedEd25519Signer {
-        SealedEd25519Signer::open(alias, tmp_dir("ed")).unwrap()
+        // Deliberate mint of a fresh mock key (open() is now re-open-only, #134).
+        SealedEd25519Signer::open_or_create(alias, tmp_dir("ed"), None).unwrap()
     }
 
     #[tokio::test]

--- a/src/ciris-verify-core/src/federation_identity.rs
+++ b/src/ciris-verify-core/src/federation_identity.rs
@@ -100,8 +100,14 @@ pub async fn create_federation_identity(
     // alias), else by the recorded `key_id` (back-compat). Decoupling lets the
     // recorded key_id move to the derived form without re-sealing every seed.
     let seal_id = seal_alias.unwrap_or(&key_id);
-    let mldsa = ciris_keyring::get_platform_sealed_mldsa65_signer(seal_id, keys_dir())
-        .map_err(keyring_err)?;
+    // CREATE is a deliberate mint-or-adopt: `open_or_create(None)` re-opens a
+    // sealed seed if present, else mints + seals a fresh one. The bare factory
+    // `get_platform_sealed_mldsa65_signer` is now **re-open-only** and fails
+    // loud (CIRISVerify#134), so identity *creation* must use this explicit path.
+    let mldsa: Box<dyn ciris_keyring::PqcSigner> = Box::new(
+        ciris_keyring::SealedMlDsa65Signer::open_or_create(seal_id, keys_dir(), None)
+            .map_err(keyring_err)?,
+    );
 
     let identity = HardwareRootedIdentity::new(key_id.clone(), hw_signer, Arc::from(mldsa))?;
     let record = produce_self_key_record(&identity, identity_type, valid_from).await?;


### PR DESCRIPTION
**Security/correctness fix.** `SealedMlDsa65Signer::open()` / `SealedEd25519Signer::open()` (and their `get_platform_*_signer` factories) delegated to `open_or_create(None)`, which on `KeyNotFound` **silently minted a fresh random seed**. So re-opening an existing identity whose sealed seed was absent produced a **brand-new key** instead of an error — swapping the PQC (or Ed25519) half of the hybrid federation identity for an unverifiable one and **destroying the original**.

A live CIRISServer fed-ID broke exactly this way: every owner-binding since failed persist's federation-tier hybrid-verify (`MlDsa65 verification failed`). This is the #275 "silently store an unverifiable key" hazard, on the **re-open** path.

## Fix
- **`open_existing()`** (new, both signers): load-only; errors `KeyNotFound`. **Never mints.**
- **`open()` ≡ `open_existing()`** — re-open contract, fail-loud. The factories re-open, so a missing seed surfaces instead of fabricating.
- **`open_or_create()`** stays the explicit **deliberate first-seal** (re-open if sealed, else `adopt(Some)` / fresh `None`) — the correct call for CREATE.
- **verify-core `create_federation_identity`**: the ML-DSA seal now uses `open_or_create(None)` (deliberate mint-or-adopt) instead of the bare factory (now re-open-only). All CLI factory uses are re-open paths ("open accord/granter identity to sign") → fail-loud is correct there.
- **Regression tests** (open/open_existing/factory error `KeyNotFound` on a missing seed, both signers) + docs corrected.

## Consumer note
Re-open paths (node startup via the factory) now **fail loud** — they must NOT recover by minting; mint only at deliberate identity creation. (cc CIRISServer — confirmed your re-open-vs-mint split already matches this.)

verify-core **737** / keyring **108 (+pqc) / 74 (default)** tests green; clippy clean. v7.5.1 carries the fix (+ the inert TPM plugin stages 1–2 already on main).

Closes #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
