### PR TITLE
fix(keyring): honest SE-vs-keychain custody log on macOS/iOS fallback (#139)

### DIFF
--- a/src/ciris-keyring/src/storage/mod.rs
+++ b/src/ciris-keyring/src/storage/mod.rs
@@ -622,11 +622,27 @@ pub fn create_platform_storage(
     {
         match SecureEnclaveSecureBlobStorage::new(&alias, &storage_dir) {
             Ok(storage) => {
-                tracing::info!(
-                    alias = %alias,
-                    hw_backed = storage.is_hardware_backed(),
-                    "Using Secure Enclave-backed secure storage for wallet seeds"
-                );
+                // The constructor may succeed yet still fall back to a
+                // keychain/software P-256 key (e.g. an unsigned macOS CLI
+                // process: SE keygen → errSecMissingEntitlement). Don't name the
+                // Enclave unless the master is actually SE-held — a
+                // "Secure Enclave-backed ... hw_backed=false" line reads, to an
+                // operator, as "it used the Enclave" when it did NOT (#139).
+                if storage.is_hardware_backed() {
+                    tracing::info!(
+                        alias = %alias,
+                        hw_backed = true,
+                        "secure storage: Secure Enclave (hardware-backed) for wallet seeds"
+                    );
+                } else {
+                    tracing::warn!(
+                        alias = %alias,
+                        hw_backed = false,
+                        "secure storage: KEYCHAIN FALLBACK — Secure Enclave unavailable, key is \
+                         software-at-rest (custody degraded; on a macOS CLI this is an \
+                         entitlement/code-signing gap, not a hardware fault)"
+                    );
+                }
                 return Ok(Box::new(storage));
             },
             Err(e) => {


### PR DESCRIPTION
## Honest SE-vs-keychain custody log on macOS/iOS fallback (#139)

`create_platform_storage`'s Secure Enclave branch hardcoded *"Using Secure Enclave-backed secure storage"* with `hw_backed = is_hardware_backed()`. When SE keygen falls back to a keychain/software P-256 key (e.g. an unsigned macOS CLI process → `errSecMissingEntitlement`), it logged the self-contradicting:

```
INFO ...storage: Using Secure Enclave-backed secure storage  alias=... hw_backed=false
```

— which reads, to an operator, as *"it used the Enclave"* when it did **not**.

### Fix
Branch on `is_hardware_backed()`:
- **real SE master** → `INFO  secure storage: Secure Enclave (hardware-backed)`
- **keychain fallback** → `WARN  secure storage: KEYCHAIN FALLBACK — Secure Enclave unavailable, key is software-at-rest (custody degraded; on a macOS CLI this is an entitlement/code-signing gap, not a hardware fault)`

The substrate log is the one operators see first, so it must not name the Enclave on fallback.

### Verification
- `cargo check -p ciris-keyring --target aarch64-apple-ios` — the `cfg(any(ios, macos))` block compiles
- Linux build unaffected (block is cfg-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
