### PR TITLE
feat(tpm): #141 stage A — signer path over the plugin ABI v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,6 +813,7 @@ dependencies = [
 name = "ciris-tpm-plugin"
 version = "7.6.0"
 dependencies = [
+ "sha2",
  "tracing",
  "tss-esapi",
 ]

--- a/src/ciris-keyring/src/tpm_plugin.rs
+++ b/src/ciris-keyring/src/tpm_plugin.rs
@@ -33,9 +33,14 @@ use libloading::{Library, Symbol};
 
 use crate::error::KeyringError;
 
-/// The ABI version this client speaks. Must match the plugin's
-/// `CIRIS_TPM_ABI_VERSION`.
-const EXPECTED_ABI_VERSION: u32 = 1;
+/// The minimum plugin ABI this client understands (v1 = `available`/`seal`/
+/// `unseal`/`free`).
+const MIN_ABI_VERSION: u32 = 1;
+/// The newest plugin ABI this client knows about (v2 = + the signer path). The
+/// client accepts any version in `[MIN, CURRENT]` and resolves newer ops lazily
+/// (a v1 plugin simply lacks the signer symbols → those methods fail-closed); it
+/// refuses a version `> CURRENT` it can't reason about (fail-closed = "no TPM").
+const CURRENT_ABI_VERSION: u32 = 2;
 
 /// Plugin C ABI return codes (mirror `ciris-tpm-plugin`).
 const CIRIS_TPM_OK: i32 = 0;
@@ -43,6 +48,11 @@ const CIRIS_TPM_OK: i32 = 0;
 type AbiVersionFn = unsafe extern "C" fn() -> u32;
 type AvailableFn = unsafe extern "C" fn() -> i32;
 type BlobOpFn = unsafe extern "C" fn(*const u8, usize, *mut *mut u8, *mut usize) -> i32;
+/// Signer-create: no input, one out-buffer (the key blob).
+type CreateFn = unsafe extern "C" fn(*mut *mut u8, *mut usize) -> i32;
+/// Signer-sign: two inputs (key blob + data), one out-buffer (the signature).
+type SignFn =
+    unsafe extern "C" fn(*const u8, usize, *const u8, usize, *mut *mut u8, *mut usize) -> i32;
 type FreeFn = unsafe extern "C" fn(*mut u8, usize);
 
 fn err(reason: impl std::fmt::Display) -> KeyringError {
@@ -91,6 +101,11 @@ pub struct TpmPlugin {
     available: AvailableFn,
     seal: BlobOpFn,
     unseal: BlobOpFn,
+    // Signer path (ABI v2): None on an older v1 plugin → those methods
+    // fail-closed with NotSupported.
+    signer_create: Option<CreateFn>,
+    signer_public: Option<BlobOpFn>,
+    signer_sign: Option<SignFn>,
     free: FreeFn,
 }
 
@@ -131,9 +146,9 @@ impl TpmPlugin {
             *s
         };
         let version = unsafe { abi_version() };
-        if version != EXPECTED_ABI_VERSION {
+        if !(MIN_ABI_VERSION..=CURRENT_ABI_VERSION).contains(&version) {
             return Err(not_supported(format!(
-                "ciris-tpm-plugin ABI v{version} unrecognized (this build speaks v{EXPECTED_ABI_VERSION})"
+                "ciris-tpm-plugin ABI v{version} unsupported (this build speaks v{MIN_ABI_VERSION}..=v{CURRENT_ABI_VERSION})"
             )));
         }
 
@@ -154,11 +169,31 @@ impl TpmPlugin {
                 .map_err(|e| err(format!("plugin missing free symbol: {e}")))?
         };
 
+        // Signer path (ABI v2): optional — absent on a v1 plugin. Resolve all
+        // three or none (a partial set is a malformed plugin → treat as absent).
+        let (signer_create, signer_public, signer_sign) = if version >= 2 {
+            // SAFETY: a v2 plugin declares all three; copy out the fn pointers.
+            unsafe {
+                let c = lib.get::<CreateFn>(b"ciris_tpm_signer_create\0").ok();
+                let p = lib.get::<BlobOpFn>(b"ciris_tpm_signer_public\0").ok();
+                let s = lib.get::<SignFn>(b"ciris_tpm_signer_sign\0").ok();
+                match (c, p, s) {
+                    (Some(c), Some(p), Some(s)) => (Some(*c), Some(*p), Some(*s)),
+                    _ => (None, None, None),
+                }
+            }
+        } else {
+            (None, None, None)
+        };
+
         Ok(Self {
             _lib: lib,
             available,
             seal,
             unseal,
+            signer_create,
+            signer_public,
+            signer_sign,
             free,
         })
     }
@@ -186,12 +221,88 @@ impl TpmPlugin {
         self.blob_op(self.unseal, blob, "unseal")
     }
 
+    /// Whether this plugin exposes the signer path (ABI v2). A v1 plugin lacks
+    /// it; the signer methods then fail-closed with [`KeyringError::NotSupported`].
+    #[must_use]
+    pub fn signer_supported(&self) -> bool {
+        self.signer_create.is_some()
+    }
+
+    /// Create an ECDSA P-256 signing key in the TPM; returns its opaque,
+    /// TPM-bound key blob (pass to [`Self::signer_public`] / [`Self::signer_sign`]).
+    ///
+    /// # Errors
+    /// [`KeyringError::NotSupported`] on a v1 plugin; [`KeyringError::HardwareError`]
+    /// if the TPM op fails.
+    pub fn signer_create(&self) -> Result<Vec<u8>, KeyringError> {
+        let op = self
+            .signer_create
+            .ok_or_else(|| not_supported("ciris-tpm-plugin has no signer path (ABI v1)"))?;
+        let mut out: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        // SAFETY: valid out-params; a successful op hands back a plugin-owned
+        // buffer freed via `free`.
+        let rc = unsafe { op(&mut out, &mut out_len) };
+        self.finish(rc, out, out_len, "signer_create")
+    }
+
+    /// Return the SEC1-uncompressed public key (`0x04 ‖ X ‖ Y`, 65 bytes) of a
+    /// signer key blob.
+    ///
+    /// # Errors
+    /// [`KeyringError::NotSupported`] on a v1 plugin; [`KeyringError::HardwareError`]
+    /// if the TPM op fails.
+    pub fn signer_public(&self, key_blob: &[u8]) -> Result<Vec<u8>, KeyringError> {
+        let op = self
+            .signer_public
+            .ok_or_else(|| not_supported("ciris-tpm-plugin has no signer path (ABI v1)"))?;
+        self.blob_op(op, key_blob, "signer_public")
+    }
+
+    /// SHA-256-hash `data` and ECDSA-sign it with `key_blob`; returns raw
+    /// `r(32) ‖ s(32)` (64 bytes).
+    ///
+    /// # Errors
+    /// [`KeyringError::NotSupported`] on a v1 plugin; [`KeyringError::HardwareError`]
+    /// if the TPM op fails.
+    pub fn signer_sign(&self, key_blob: &[u8], data: &[u8]) -> Result<Vec<u8>, KeyringError> {
+        let op = self
+            .signer_sign
+            .ok_or_else(|| not_supported("ciris-tpm-plugin has no signer path (ABI v1)"))?;
+        let mut out: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        // SAFETY: `key_blob`/`data` are valid slices; valid out-params.
+        let rc = unsafe {
+            op(
+                key_blob.as_ptr(),
+                key_blob.len(),
+                data.as_ptr(),
+                data.len(),
+                &mut out,
+                &mut out_len,
+            )
+        };
+        self.finish(rc, out, out_len, "signer_sign")
+    }
+
     fn blob_op(&self, op: BlobOpFn, input: &[u8], what: &str) -> Result<Vec<u8>, KeyringError> {
         let mut out: *mut u8 = std::ptr::null_mut();
         let mut out_len: usize = 0;
         // SAFETY: `input` is a valid slice; `out`/`out_len` are valid out-params;
         // a successful op hands back a plugin-owned buffer we free via `free`.
         let rc = unsafe { op(input.as_ptr(), input.len(), &mut out, &mut out_len) };
+        self.finish(rc, out, out_len, what)
+    }
+
+    /// Common tail for every op: check the return code, copy out the
+    /// plugin-owned buffer, free it, and return the bytes.
+    fn finish(
+        &self,
+        rc: i32,
+        out: *mut u8,
+        out_len: usize,
+        what: &str,
+    ) -> Result<Vec<u8>, KeyringError> {
         if rc != CIRIS_TPM_OK {
             return Err(err(format!("ciris-tpm-plugin {what} failed (code {rc})")));
         }

--- a/src/ciris-keyring/tests/tpm_plugin_load.rs
+++ b/src/ciris-keyring/tests/tpm_plugin_load.rs
@@ -45,4 +45,73 @@ fn loads_real_plugin_and_completes_abi_handshake() {
         plugin.seal(b"seed").is_err(),
         "stub seal must error, not succeed or panic"
     );
+
+    // Signer path (ABI v2): the symbols are present (the built plugin is v2), so
+    // the client reports the signer is supported — but with no TPM the ops fail
+    // cleanly rather than panicking or fabricating a key/signature.
+    assert!(
+        plugin.signer_supported(),
+        "v2 plugin must expose the signer path"
+    );
+    assert!(plugin.signer_create().is_err(), "stub signer_create errors");
+    assert!(
+        plugin.signer_public(b"blob").is_err(),
+        "stub signer_public errors"
+    );
+    assert!(
+        plugin.signer_sign(b"blob", b"data").is_err(),
+        "stub signer_sign errors"
+    );
+}
+
+/// Hardware validation of the ABI-v2 signer path (#141) against a **real** TPM.
+///
+/// `#[ignore]`d so it never runs in normal `cargo test` / CI (which load the
+/// stub and have no TPM). To run on a box with a TPM:
+///
+/// ```text
+/// cargo build -p ciris-tpm-plugin --features real
+/// CIRIS_TPM_PLUGIN=target/debug/libciris_tpm_plugin.so \
+///   cargo test -p ciris-keyring --features tpm-plugin \
+///   --test tpm_plugin_load -- --ignored --nocapture
+/// ```
+///
+/// Proves the create → public → sign port round-trips end-to-end: the TPM-held
+/// key signs and the signature verifies under the exported SEC1 public key.
+#[test]
+#[ignore = "requires a real TPM + the `real` plugin via CIRIS_TPM_PLUGIN"]
+fn signer_roundtrip_verifies_on_real_tpm() {
+    use p256::ecdsa::signature::Verifier;
+
+    let path = std::env::var_os("CIRIS_TPM_PLUGIN")
+        .or_else(|| built_plugin().map(Into::into))
+        .expect("set CIRIS_TPM_PLUGIN to a `real` plugin .so");
+    let plugin = TpmPlugin::load_from(&path).expect("plugin loads");
+    if !plugin.available() {
+        eprintln!("no usable TPM; skipping hardware roundtrip");
+        return;
+    }
+
+    let key_blob = plugin.signer_create().expect("create signing key");
+    let pubkey = plugin.signer_public(&key_blob).expect("read public key");
+    assert_eq!(pubkey.len(), 65, "SEC1 uncompressed P-256 key");
+    assert_eq!(pubkey[0], 0x04, "uncompressed point marker");
+
+    let message = b"ciris-tpm-plugin signer hardware validation #141";
+    let sig_bytes = plugin.signer_sign(&key_blob, message).expect("sign");
+    assert_eq!(sig_bytes.len(), 64, "raw r||s");
+
+    let verifying_key =
+        p256::ecdsa::VerifyingKey::from_sec1_bytes(&pubkey).expect("valid SEC1 pubkey");
+    let signature = p256::ecdsa::Signature::from_slice(&sig_bytes).expect("valid r||s");
+    verifying_key
+        .verify(message, &signature)
+        .expect("TPM signature must verify under the exported public key");
+
+    // A different message must NOT verify with the same signature.
+    assert!(
+        verifying_key.verify(b"tampered", &signature).is_err(),
+        "signature must not verify for a different message"
+    );
+    eprintln!("✓ TPM signer roundtrip verified on real hardware");
 }

--- a/src/ciris-tpm-plugin/Cargo.toml
+++ b/src/ciris-tpm-plugin/Cargo.toml
@@ -20,10 +20,13 @@ crate-type = ["cdylib", "rlib"]
 # where tss-esapi can link. This is what lets the *keyring* drop its hard tss2
 # link entirely (it dlopens this instead).
 default = []
-real = ["tss-esapi"]
+real = ["tss-esapi", "dep:sha2"]
 
 [dependencies]
 tracing.workspace = true
+# SHA-256 for the signer path (#141) — hashing data before ECDSA. Pure Rust,
+# pulled only by `real` (the stub backend never hashes).
+sha2 = { workspace = true, optional = true }
 
 # tss-esapi link-binds the system tss2 C libs → glibc-linux + windows only
 # (no aarch64-musl libtss2). The crate still *builds* everywhere without `real`;

--- a/src/ciris-tpm-plugin/src/backend.rs
+++ b/src/ciris-tpm-plugin/src/backend.rs
@@ -25,8 +25,9 @@ mod imp {
             resource_handles::Hierarchy,
         },
         structures::{
-            EccPoint, EccScheme, KeyDerivationFunctionScheme, KeyedHashScheme, Private, Public,
-            PublicBuilder, PublicEccParametersBuilder, PublicKeyedHashParameters, SensitiveData,
+            Digest, EccPoint, EccScheme, HashScheme, HashcheckTicket, KeyDerivationFunctionScheme,
+            KeyedHashScheme, Private, Public, PublicBuilder, PublicEccParametersBuilder,
+            PublicKeyedHashParameters, SensitiveData, Signature, SignatureScheme,
             SymmetricDefinitionObject,
         },
         tcti_ldr::TctiNameConf,
@@ -198,6 +199,189 @@ mod imp {
 
         Ok(unsealed.value().to_vec())
     }
+
+    // ----------------------------------------------------------------------
+    // Signer path (#141, ABI v2): a non-restricted ECC P-256 (ECDSA-SHA256)
+    // signing key created under the SRK, persisted as the same opaque blob
+    // shape as seal (`u32_le(private_len) ‖ private ‖ public`). Pure: the
+    // keyring owns the blob; the plugin loads it transiently per op. Faithful
+    // port of `ciris_keyring::platform::tpm::{create_signing_key, tpm_sign,
+    // extract_ecdsa_signature, extract_public_key_from_public}`.
+    // ----------------------------------------------------------------------
+
+    /// Create a non-restricted ECDSA P-256 signing key under the SRK and return
+    /// its persistable blob (`u32_le(private_len) ‖ private ‖ public`).
+    pub fn signer_create() -> Result<Vec<u8>, String> {
+        let mut context = create_context()?;
+        let primary = get_or_create_primary(&mut context)?;
+
+        let object_attributes = ObjectAttributesBuilder::new()
+            .with_fixed_tpm(true)
+            .with_fixed_parent(true)
+            .with_sensitive_data_origin(true)
+            .with_user_with_auth(true)
+            .with_sign_encrypt(true)
+            .build()
+            .map_err(|e| format!("signer attrs: {e}"))?;
+
+        let ecc_params = PublicEccParametersBuilder::new()
+            .with_ecc_scheme(EccScheme::EcDsa(HashScheme::new(HashingAlgorithm::Sha256)))
+            .with_curve(EccCurve::NistP256)
+            .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+            .with_symmetric(SymmetricDefinitionObject::Null)
+            .with_is_signing_key(true)
+            .with_is_decryption_key(false)
+            .with_restricted(false)
+            .build()
+            .map_err(|e| format!("signer ecc params: {e}"))?;
+
+        let signing_public = PublicBuilder::new()
+            .with_public_algorithm(PublicAlgorithm::Ecc)
+            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+            .with_object_attributes(object_attributes)
+            .with_ecc_parameters(ecc_params)
+            .with_ecc_unique_identifier(EccPoint::default())
+            .build()
+            .map_err(|e| format!("signer public: {e}"))?;
+
+        let result = context
+            .execute_with_nullauth_session(|ctx| {
+                ctx.create(primary, signing_public.clone(), None, None, None, None)
+            })
+            .map_err(|e| format!("TPM2_Create (signer): {e}"))?;
+
+        let private_blob = result.out_private.to_vec();
+        let public_blob = result
+            .out_public
+            .marshall()
+            .map_err(|e| format!("marshall signer public: {e}"))?;
+        let _ = context.flush_context(primary.into());
+
+        frame_blob(private_blob, public_blob)
+    }
+
+    /// Load a signer blob and return its SEC1-uncompressed public key
+    /// (`0x04 ‖ X(32) ‖ Y(32)`, 65 bytes).
+    pub fn signer_public(blob: &[u8]) -> Result<Vec<u8>, String> {
+        let (private, public) = parse_blob(blob)?;
+        let mut context = create_context()?;
+        let primary = get_or_create_primary(&mut context)?;
+        let loaded = context
+            .execute_with_nullauth_session(|ctx| ctx.load(primary, private, public))
+            .map_err(|e| format!("TPM2_Load (signer, wrong TPM?): {e}"))?;
+        let (public, _, _) = context
+            .execute_without_session(|ctx| ctx.read_public(loaded))
+            .map_err(|e| format!("read_public (signer): {e}"))?;
+        let _ = context.flush_context(loaded.into());
+        let _ = context.flush_context(primary.into());
+        extract_public_key(&public)
+    }
+
+    /// Load a signer blob, hash `data` with SHA-256, and ECDSA-sign it →
+    /// raw `r(32) ‖ s(32)` (64 bytes).
+    pub fn signer_sign(blob: &[u8], data: &[u8]) -> Result<Vec<u8>, String> {
+        use sha2::{Digest as _, Sha256};
+
+        let (private, public) = parse_blob(blob)?;
+        let mut context = create_context()?;
+        let primary = get_or_create_primary(&mut context)?;
+        let key = context
+            .execute_with_nullauth_session(|ctx| ctx.load(primary, private, public))
+            .map_err(|e| format!("TPM2_Load (signer, wrong TPM?): {e}"))?;
+
+        let hash = Sha256::digest(data);
+        let digest = Digest::try_from(&hash[..]).map_err(|e| format!("signer digest: {e}"))?;
+
+        // External (non-TPM-generated) data signs under a NULL-hierarchy ticket.
+        let validation = HashcheckTicket::try_from(tss_esapi::tss2_esys::TPMT_TK_HASHCHECK {
+            tag: tss_esapi::constants::tss::TPM2_ST_HASHCHECK,
+            hierarchy: tss_esapi::constants::tss::TPM2_RH_NULL,
+            digest: tss_esapi::tss2_esys::TPM2B_DIGEST {
+                size: 0,
+                buffer: [0; 64],
+            },
+        })
+        .map_err(|e| format!("signer validation ticket: {e}"))?;
+
+        let signature = context
+            .execute_with_nullauth_session(|ctx| {
+                ctx.sign(
+                    key,
+                    digest.clone(),
+                    SignatureScheme::EcDsa {
+                        hash_scheme: HashScheme::new(HashingAlgorithm::Sha256),
+                    },
+                    validation.clone(),
+                )
+            })
+            .map_err(|e| format!("TPM2_Sign (signer): {e}"))?;
+        let _ = context.flush_context(key.into());
+        let _ = context.flush_context(primary.into());
+
+        extract_ecdsa_signature(&signature)
+    }
+
+    /// `u32_le(private_len) ‖ private ‖ public` — the opaque blob framing
+    /// shared with seal.
+    fn frame_blob(private: Vec<u8>, public: Vec<u8>) -> Result<Vec<u8>, String> {
+        let plen = u32::try_from(private.len()).map_err(|_| "private blob too large")?;
+        let mut blob = Vec::with_capacity(4 + private.len() + public.len());
+        blob.extend_from_slice(&plen.to_le_bytes());
+        blob.extend_from_slice(&private);
+        blob.extend_from_slice(&public);
+        Ok(blob)
+    }
+
+    fn parse_blob(blob: &[u8]) -> Result<(Private, Public), String> {
+        if blob.len() < 4 {
+            return Err("signer blob too short".into());
+        }
+        let plen = u32::from_le_bytes([blob[0], blob[1], blob[2], blob[3]]) as usize;
+        if blob.len() < 4 + plen {
+            return Err("signer blob truncated".into());
+        }
+        let private = Private::try_from(blob[4..4 + plen].to_vec())
+            .map_err(|e| format!("signer private: {e}"))?;
+        let public =
+            Public::unmarshall(&blob[4 + plen..]).map_err(|e| format!("signer public: {e}"))?;
+        Ok((private, public))
+    }
+
+    /// SEC1-uncompressed pubkey from an ECC `Public` (`0x04 ‖ X ‖ Y`).
+    fn extract_public_key(public: &Public) -> Result<Vec<u8>, String> {
+        let ecc_point = match public {
+            Public::Ecc { unique, .. } => unique,
+            _ => return Err("expected ECC public key".into()),
+        };
+        let x = ecc_point.x().value();
+        let y = ecc_point.y().value();
+        let mut out = Vec::with_capacity(65);
+        out.push(0x04);
+        pad32(&mut out, x);
+        pad32(&mut out, y);
+        Ok(out)
+    }
+
+    /// Raw `r(32) ‖ s(32)` from a TPM ECDSA `Signature`.
+    fn extract_ecdsa_signature(signature: &Signature) -> Result<Vec<u8>, String> {
+        match signature {
+            Signature::EcDsa(sig) => {
+                let mut out = Vec::with_capacity(64);
+                pad32(&mut out, sig.signature_r().value());
+                pad32(&mut out, sig.signature_s().value());
+                Ok(out)
+            },
+            _ => Err("unexpected signature type from TPM".into()),
+        }
+    }
+
+    /// Left-pad `bytes` to 32 (or take the low 32) and append.
+    fn pad32(out: &mut Vec<u8>, bytes: &[u8]) {
+        if bytes.len() < 32 {
+            out.extend(std::iter::repeat_n(0u8, 32 - bytes.len()));
+        }
+        out.extend(&bytes[bytes.len().saturating_sub(32)..]);
+    }
 }
 
 #[cfg(not(all(
@@ -214,6 +398,15 @@ mod imp {
     pub fn unseal(_blob: &[u8]) -> Result<Vec<u8>, String> {
         Err("ciris-tpm-plugin built without the `real` backend".to_string())
     }
+    pub fn signer_create() -> Result<Vec<u8>, String> {
+        Err("ciris-tpm-plugin built without the `real` backend".to_string())
+    }
+    pub fn signer_public(_blob: &[u8]) -> Result<Vec<u8>, String> {
+        Err("ciris-tpm-plugin built without the `real` backend".to_string())
+    }
+    pub fn signer_sign(_blob: &[u8], _data: &[u8]) -> Result<Vec<u8>, String> {
+        Err("ciris-tpm-plugin built without the `real` backend".to_string())
+    }
 }
 
-pub use imp::{available, seal, unseal};
+pub use imp::{available, seal, signer_create, signer_public, signer_sign, unseal};

--- a/src/ciris-tpm-plugin/src/lib.rs
+++ b/src/ciris-tpm-plugin/src/lib.rs
@@ -40,9 +40,14 @@
 
 #![allow(clippy::missing_safety_doc)]
 
-/// ABI version. Bump on any breaking change to an exported signature; the
-/// keyring refuses to load a plugin whose version it doesn't recognize.
-pub const CIRIS_TPM_ABI_VERSION: u32 = 1;
+/// ABI version. Bump on any **additive** revision so a client can detect which
+/// ops exist; the keyring accepts any version in its supported range and
+/// resolves newer ops lazily (fail-closed if a symbol is absent).
+///
+/// - **v1:** `available` / `seal` / `unseal` / `free`.
+/// - **v2 (#141):** adds the signer path — `signer_create` / `signer_public` /
+///   `signer_sign` (ECDSA P-256, stateless blob-based).
+pub const CIRIS_TPM_ABI_VERSION: u32 = 2;
 
 /// Operation succeeded.
 pub const CIRIS_TPM_OK: i32 = 0;
@@ -154,6 +159,98 @@ pub unsafe extern "C" fn ciris_tpm_unseal(
     }
 }
 
+/// Create an ECDSA P-256 signing key in the TPM → its persistable key blob in
+/// `out`/`out_len` (ABI v2, #141).
+///
+/// The blob is opaque (`u32_le(private_len) ‖ private ‖ public`) and bound to
+/// this TPM (only it can load + sign with it). The keyring stores the blob and
+/// passes it back to [`ciris_tpm_signer_public`] / [`ciris_tpm_signer_sign`].
+/// Returns [`CIRIS_TPM_OK`], [`CIRIS_TPM_UNAVAILABLE`], or [`CIRIS_TPM_ERROR`].
+///
+/// # Safety
+/// `out`/`out_len` valid; the returned buffer is freed via [`ciris_tpm_free`].
+#[no_mangle]
+pub unsafe extern "C" fn ciris_tpm_signer_create(out: *mut *mut u8, out_len: *mut usize) -> i32 {
+    if out.is_null() || out_len.is_null() {
+        return CIRIS_TPM_ERROR;
+    }
+    match backend::signer_create() {
+        Ok(blob) => {
+            emit(blob, out, out_len);
+            CIRIS_TPM_OK
+        },
+        Err(e) => {
+            tracing::error!("ciris_tpm_signer_create: {e}");
+            CIRIS_TPM_ERROR
+        },
+    }
+}
+
+/// Load a signer blob from [`ciris_tpm_signer_create`] → its SEC1-uncompressed
+/// public key (`0x04 ‖ X(32) ‖ Y(32)`, 65 bytes) in `out`/`out_len`.
+///
+/// # Safety
+/// `blob` valid for `blob_len`; `out`/`out_len` valid. Buffer freed via
+/// [`ciris_tpm_free`].
+#[no_mangle]
+pub unsafe extern "C" fn ciris_tpm_signer_public(
+    blob: *const u8,
+    blob_len: usize,
+    out: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    if blob.is_null() || out.is_null() || out_len.is_null() {
+        return CIRIS_TPM_ERROR;
+    }
+    let blob = std::slice::from_raw_parts(blob, blob_len);
+    match backend::signer_public(blob) {
+        Ok(pk) => {
+            emit(pk, out, out_len);
+            CIRIS_TPM_OK
+        },
+        Err(e) => {
+            tracing::error!("ciris_tpm_signer_public: {e}");
+            CIRIS_TPM_ERROR
+        },
+    }
+}
+
+/// Load a signer blob, SHA-256-hash `data`, and ECDSA-sign it → raw
+/// `r(32) ‖ s(32)` (64 bytes) in `out`/`out_len`.
+///
+/// # Safety
+/// `blob` valid for `blob_len`; `data` valid for `data_len` (or null iff
+/// `data_len == 0`); `out`/`out_len` valid. Buffer freed via [`ciris_tpm_free`].
+#[no_mangle]
+pub unsafe extern "C" fn ciris_tpm_signer_sign(
+    blob: *const u8,
+    blob_len: usize,
+    data: *const u8,
+    data_len: usize,
+    out: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    if blob.is_null() || out.is_null() || out_len.is_null() || (data.is_null() && data_len != 0) {
+        return CIRIS_TPM_ERROR;
+    }
+    let blob = std::slice::from_raw_parts(blob, blob_len);
+    let data = if data_len == 0 {
+        &[][..]
+    } else {
+        std::slice::from_raw_parts(data, data_len)
+    };
+    match backend::signer_sign(blob, data) {
+        Ok(sig) => {
+            emit(sig, out, out_len);
+            CIRIS_TPM_OK
+        },
+        Err(e) => {
+            tracing::error!("ciris_tpm_signer_sign: {e}");
+            CIRIS_TPM_ERROR
+        },
+    }
+}
+
 /// The TPM backend — real (`tss-esapi`, gnu/win) or stub. See `backend.rs`.
 mod backend;
 
@@ -195,5 +292,38 @@ mod tests {
         // Default build (no `real`) must report unavailable, never crash.
         #[cfg(not(feature = "real"))]
         assert_eq!(ciris_tpm_available(), CIRIS_TPM_UNAVAILABLE);
+    }
+
+    #[test]
+    fn abi_version_advertises_v2_signer() {
+        // The signer path (#141) is ABI v2; the version must advertise it so a
+        // client can resolve the signer symbols.
+        assert!(ciris_tpm_plugin_abi_version() >= 2);
+    }
+
+    #[test]
+    fn signer_create_fails_closed_without_a_tpm() {
+        // No TPM in any test env → signer_create must never report success.
+        let mut out: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        let rc = unsafe { ciris_tpm_signer_create(&mut out, &mut out_len) };
+        assert_ne!(rc, CIRIS_TPM_OK, "signer_create must fail closed");
+    }
+
+    #[test]
+    fn signer_null_pointers_are_rejected() {
+        let rc = unsafe { ciris_tpm_signer_create(std::ptr::null_mut(), std::ptr::null_mut()) };
+        assert_eq!(rc, CIRIS_TPM_ERROR);
+        let rc = unsafe {
+            ciris_tpm_signer_sign(
+                std::ptr::null(),
+                0,
+                std::ptr::null(),
+                0,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, CIRIS_TPM_ERROR);
     }
 }


### PR DESCRIPTION
## #141 stage A — the signer path over the plugin ABI (v2)

First step of removing the **signer** half of `tss-esapi` from `ciris-keyring` (v7.6.0 already moved seal/unseal). Adds a stateless, blob-based ECDSA P-256 signing path to the plugin C ABI + the keyring `dlopen` client — same *"keyring owns persistence, plugin does the TPM op transiently"* shape as seal/unseal.

### Plugin (`ciris-tpm-plugin`)
- **ABI v2** (additive). New C symbols:
  - `ciris_tpm_signer_create(out)` → opaque, TPM-bound key blob
  - `ciris_tpm_signer_public(blob)` → SEC1 pubkey (`0x04‖X‖Y`, 65 B)
  - `ciris_tpm_signer_sign(blob, data)` → raw `r‖s` (64 B)
- Real backend: faithful port of `platform/tpm::{create_signing_key, tpm_sign, extract_ecdsa_signature, extract_public_key_from_public}` — a non-restricted ECDSA-SHA256 P-256 key under the SRK, persisted as the same `u32_le(private_len)‖private‖public` framing as seal. Pure (no I/O).
- Stub backend + fail-closed C-ABI tests for the new surface.

### Keyring client (`ciris_keyring::tpm_plugin`)
- ABI acceptance is now a **range [v1, v2]**; signer symbols resolve **lazily** — a v1 plugin → `signer_supported() == false`, methods fail-closed with `NotSupported`. Refuses a version `> CURRENT` (fail-closed = "no TPM").
- `TpmPlugin::{signer_supported, signer_create, signer_public, signer_sign}`.

### Hardware-validated ✅
An `#[ignore]`d integration test ran against a real `/dev/tpmrm0`: **create → public → sign → p256 ECDSA verify** all pass, and a tampered message fails verification. (Skips in CI — stub plugin + no TPM.)

### Verification
- keyring lib **77** green; plugin **7** green; clippy clean on stub + real + keyring

### Next (#141)
- stage B: `PluginTpmSigner: HardwareSigner` + factory wiring
- stage C: quote/attestation port
- stage D: default flip → delete the link-time `tpm`/`tss-esapi` dep from the keyring

🤖 Generated with [Claude Code](https://claude.com/claude-code)
