### PR TITLE
feat(tpm): #141 stage B — PluginTpmSigner HardwareSigner + factory wiring

### DIFF
--- a/src/ciris-keyring/src/platform/factory.rs
+++ b/src/ciris-keyring/src/platform/factory.rs
@@ -238,6 +238,37 @@ pub fn create_hardware_signer(
         });
     }
 
+    // Opportunistic runtime-loaded TPM signer (CIRISVerify#141). Reaches TPM via
+    // the `dlopen` plugin with no tss-esapi link, so it covers the wheel + musl +
+    // any tpm-less build where the plugin .so + a device are present. Tried only
+    // where the link-time `TpmSigner` arm WON'T run (i.e. not a gnu-linux/windows
+    // build with the `tpm` feature) so existing link-tpm deployments keep their
+    // `.tpm` key. Gated by the plugin's own `available()` — a no-op fall-through
+    // where no plugin/TPM exists.
+    #[cfg(all(
+        feature = "tpm-plugin",
+        not(all(
+            feature = "tpm",
+            any(all(target_os = "linux", target_env = "gnu"), target_os = "windows")
+        ))
+    ))]
+    {
+        match super::tpm_plugin_signer::PluginTpmSigner::open(alias, default_key_dir()) {
+            Ok(signer) => {
+                tracing::info!("Using ciris-tpm-plugin (dlopen) TPM signer for hardware security");
+                let boxed: Box<dyn HardwareSigner> = Box::new(signer);
+                log_storage_descriptor(boxed.as_ref());
+                return Ok(boxed);
+            },
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "TPM plugin signer unavailable, continuing signer selection"
+                );
+            },
+        }
+    }
+
     let signer: Box<dyn HardwareSigner> = {
         #[cfg(target_os = "android")]
         {

--- a/src/ciris-keyring/src/platform/mod.rs
+++ b/src/ciris-keyring/src/platform/mod.rs
@@ -22,6 +22,12 @@ pub mod tpm;
 #[cfg(all(feature = "tpm-windows", target_os = "windows"))]
 pub mod tpm_windows;
 
+// Runtime-loaded TPM signer (CIRISVerify#141) — the ECDSA P-256 `HardwareSigner`
+// over the `dlopen` plugin, so the native TPM signing path works on every target
+// that can load the plugin (incl. the wheel + musl), with no tss-esapi link.
+#[cfg(feature = "tpm-plugin")]
+pub mod tpm_plugin_signer;
+
 mod factory;
 
 pub use factory::{
@@ -37,6 +43,9 @@ pub use ios::{SecureEnclaveSigner, SecureEnclaveWrappedEd25519Signer};
 
 #[cfg(any(all(target_os = "linux", target_env = "gnu"), target_os = "windows"))]
 pub use tpm::TpmSigner;
+
+#[cfg(feature = "tpm-plugin")]
+pub use tpm_plugin_signer::PluginTpmSigner;
 
 // Windows-native TPM signer (experimental)
 #[cfg(all(feature = "tpm-windows", target_os = "windows"))]

--- a/src/ciris-keyring/src/platform/tpm_plugin_signer.rs
+++ b/src/ciris-keyring/src/platform/tpm_plugin_signer.rs
@@ -1,0 +1,222 @@
+//! `HardwareSigner` over the runtime-loaded TPM plugin (CIRISVerify#141, stage B).
+//!
+//! The `dlopen` counterpart to [`crate::platform::tpm::TpmSigner`]: an ECDSA
+//! P-256 signing key held inside the TPM, driven through the `ciris-tpm-plugin`
+//! C ABI ([`crate::tpm_plugin`]) instead of link-bound `tss-esapi`. So the
+//! native TPM *signing* path works on every target that can load the plugin
+//! (incl. the wheel + musl), carrying no `tss-esapi` in the keyring link graph.
+//!
+//! ## Persistence
+//!
+//! The plugin's `signer_create` returns an opaque, **TPM-wrapped** key blob
+//! (`TPM2B_PRIVATE`/`PUBLIC`): the private half is sealed to this TPM, so the
+//! blob is safe to store as a plain file — only the TPM can load it. We persist
+//! it at `{alias}.tpmplugin_signer`, exactly the at-rest model the link-time
+//! `TpmSigner` uses for its `.tpm` envelope.
+//!
+//! ## Re-open discipline (CIRISVerify#134)
+//!
+//! If the blob file exists but the plugin can't load it (no TPM, or a *different*
+//! TPM), [`PluginTpmSigner::open`] returns an error — it never silently mints a
+//! fresh key, which would orphan the identity it was supposed to re-open.
+//!
+//! ## Attestation
+//!
+//! Stage B reports a [`HardwareType::TpmFirmware`] attestation with **no quote**
+//! (`quote: None`) — honest: the signing key is TPM-held, but the quote /
+//! EK-cert path is the stage-C port. It is **not** a software attestation, so
+//! consumers see TPM custody without an over-claimed quote.
+
+#![cfg(feature = "tpm-plugin")]
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use crate::error::KeyringError;
+use crate::signer::{HardwareSigner, KeyGenConfig};
+use crate::tpm_plugin::TpmPlugin;
+use crate::types::{
+    ClassicalAlgorithm, HardwareType, PlatformAttestation, StorageDescriptor, TpmAttestation,
+};
+
+/// An ECDSA P-256 signer whose key lives in the TPM, reached via the plugin.
+pub struct PluginTpmSigner {
+    alias: String,
+    blob_path: PathBuf,
+    plugin: TpmPlugin,
+    /// The TPM-wrapped key blob (private half sealed to this TPM).
+    key_blob: Vec<u8>,
+    /// SEC1-uncompressed public key (`0x04 ‖ X ‖ Y`), cached at open.
+    public_key: Vec<u8>,
+    /// Serializes TPM access (the device is single-threaded; the plugin ops are
+    /// blocking). Held only across a single op.
+    lock: Mutex<()>,
+}
+
+impl PluginTpmSigner {
+    /// Open (or, on first use, create) the plugin-backed TPM signing key for
+    /// `alias` under `storage_dir`.
+    ///
+    /// # Errors
+    /// [`KeyringError::NotSupported`] if no plugin / TPM / signer ABI is present
+    /// (the factory falls back); [`KeyringError::HardwareError`] if a present
+    /// blob cannot be loaded (wrong TPM — **never** re-minted) or a TPM op fails;
+    /// [`KeyringError::StorageFailed`] on I/O.
+    pub fn open(
+        alias: impl Into<String>,
+        storage_dir: impl Into<PathBuf>,
+    ) -> Result<Self, KeyringError> {
+        let alias = alias.into();
+        let storage_dir = storage_dir.into();
+
+        let plugin = TpmPlugin::load()?;
+        if !plugin.available() {
+            return Err(KeyringError::NotSupported {
+                operation: "ciris-tpm-plugin reports no usable TPM device".to_string(),
+            });
+        }
+        if !plugin.signer_supported() {
+            return Err(KeyringError::NotSupported {
+                operation: "ciris-tpm-plugin has no signer path (ABI v1)".to_string(),
+            });
+        }
+
+        std::fs::create_dir_all(&storage_dir).map_err(|e| KeyringError::StorageFailed {
+            reason: format!("create storage dir: {e}"),
+        })?;
+        let blob_path = storage_dir.join(format!("{alias}.tpmplugin_signer"));
+
+        let key_blob = if blob_path.exists() {
+            std::fs::read(&blob_path).map_err(|e| KeyringError::StorageFailed {
+                reason: format!("read signer blob: {e}"),
+            })?
+        } else {
+            let blob = plugin.signer_create()?;
+            write_atomic(&blob_path, &blob)?;
+            blob
+        };
+
+        // Resolve the public key now — this also proves the blob loads on THIS
+        // TPM. A present-but-unloadable blob errors here (wrong TPM), never a
+        // silent re-mint (#134).
+        let public_key = plugin.signer_public(&key_blob)?;
+
+        Ok(Self {
+            alias,
+            blob_path,
+            plugin,
+            key_blob,
+            public_key,
+            lock: Mutex::new(()),
+        })
+    }
+}
+
+fn write_atomic(path: &std::path::Path, data: &[u8]) -> Result<(), KeyringError> {
+    let temp = path.with_extension("tmp");
+    std::fs::write(&temp, data).map_err(|e| KeyringError::StorageFailed {
+        reason: format!("write temp: {e}"),
+    })?;
+    std::fs::rename(&temp, path).map_err(|e| KeyringError::StorageFailed {
+        reason: format!("rename into place: {e}"),
+    })?;
+    Ok(())
+}
+
+#[async_trait]
+impl HardwareSigner for PluginTpmSigner {
+    fn algorithm(&self) -> ClassicalAlgorithm {
+        ClassicalAlgorithm::EcdsaP256
+    }
+
+    fn hardware_type(&self) -> HardwareType {
+        // Conservative: the plugin doesn't probe discrete-vs-firmware (that needs
+        // TPM properties, a stage-C concern), so report the lower-claim fTPM.
+        HardwareType::TpmFirmware
+    }
+
+    async fn public_key(&self) -> Result<Vec<u8>, KeyringError> {
+        Ok(self.public_key.clone())
+    }
+
+    async fn sign(&self, data: &[u8]) -> Result<Vec<u8>, KeyringError> {
+        let _guard = self.lock.lock().map_err(|_| KeyringError::HardwareError {
+            reason: "TPM plugin lock poisoned".into(),
+        })?;
+        self.plugin.signer_sign(&self.key_blob, data)
+    }
+
+    async fn attestation(&self) -> Result<PlatformAttestation, KeyringError> {
+        // Stage B: TPM-held signing key, but the quote/EK port is stage C — so
+        // report a TPM attestation with no quote (honest, not over-claimed, and
+        // NOT a software attestation).
+        Ok(PlatformAttestation::Tpm(TpmAttestation {
+            tpm_version: "2.0".to_string(),
+            manufacturer: "unknown".to_string(),
+            discrete: false,
+            quote: None,
+            ek_cert: None,
+            ak_public_key: None,
+        }))
+    }
+
+    async fn generate_key(&self, _config: &KeyGenConfig) -> Result<(), KeyringError> {
+        // The signing key is provisioned at `open`; this is idempotent (mirrors
+        // the link-time TpmSigner's lenient ensure-key behavior).
+        Ok(())
+    }
+
+    async fn key_exists(&self, _alias: &str) -> Result<bool, KeyringError> {
+        Ok(self.blob_path.exists())
+    }
+
+    async fn delete_key(&self, _alias: &str) -> Result<(), KeyringError> {
+        if self.blob_path.exists() {
+            std::fs::remove_file(&self.blob_path).map_err(|e| KeyringError::StorageFailed {
+                reason: format!("delete signer blob: {e}"),
+            })?;
+        }
+        Ok(())
+    }
+
+    fn current_alias(&self) -> &str {
+        &self.alias
+    }
+
+    fn storage_descriptor(&self) -> StorageDescriptor {
+        // The private half is TPM-wrapped, but unlike the link-time TpmSigner
+        // (in-TPM handle, no file) we DO persist a wrapped envelope on disk —
+        // point the descriptor at it.
+        StorageDescriptor::Hardware {
+            hardware_type: self.hardware_type(),
+            blob_path: Some(self.blob_path.clone()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_degrades_to_not_supported_without_plugin() {
+        // No loadable plugin → open() returns NotSupported so the factory falls
+        // back (never panics, never mints an unsealed key). Deterministic: the
+        // bare plugin name won't resolve a usable TPM signer in the test env.
+        let dir = std::env::temp_dir().join(format!("ciris-plugsigner-{}", std::process::id()));
+        // load_from a path that can't exist proves the contract without mutating
+        // the process-global env.
+        let err = TpmPlugin::load_from("/nonexistent/libciris_tpm_plugin.so").err();
+        assert!(
+            matches!(err, Some(KeyringError::NotSupported { .. })),
+            "missing plugin must be NotSupported, got {err:?}"
+        );
+        let _ = dir;
+    }
+
+    // The create/sign round-trip needs a real TPM + the `real` plugin, validated
+    // on hardware via the `signer_roundtrip_verifies_on_real_tpm` integration
+    // test (#141 stage A). CI loads the stub + has no TPM.
+}

--- a/src/ciris-keyring/tests/tpm_plugin_load.rs
+++ b/src/ciris-keyring/tests/tpm_plugin_load.rs
@@ -115,3 +115,62 @@ fn signer_roundtrip_verifies_on_real_tpm() {
     );
     eprintln!("✓ TPM signer roundtrip verified on real hardware");
 }
+
+/// Hardware validation of `PluginTpmSigner` (the `HardwareSigner` wrapper, #141
+/// stage B): the full open → public_key → sign → verify path, plus the #134
+/// re-open discipline (a second `open` of the same alias loads the persisted
+/// blob and reproduces the SAME key — it does not mint a fresh one).
+///
+/// `#[ignore]`d; run as in [`signer_roundtrip_verifies_on_real_tpm`].
+#[tokio::test]
+#[ignore = "requires a real TPM + the `real` plugin via CIRIS_TPM_PLUGIN"]
+async fn plugin_tpm_signer_persists_and_reopens_on_real_tpm() {
+    use ciris_keyring::platform::PluginTpmSigner;
+    use ciris_keyring::HardwareSigner;
+    use p256::ecdsa::signature::Verifier;
+
+    // The factory loads the plugin by name; the hardware test points at the real
+    // one via CIRIS_TPM_PLUGIN, which PluginTpmSigner::open honors through the
+    // client's plugin_path(). Skip if it can't reach a TPM.
+    if std::env::var_os("CIRIS_TPM_PLUGIN").is_none() {
+        if let Some(p) = built_plugin() {
+            std::env::set_var("CIRIS_TPM_PLUGIN", p);
+        }
+    }
+
+    let dir = std::env::temp_dir().join(format!("ciris-plugsigner-hw-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+
+    let signer = match PluginTpmSigner::open("fed-ecdsa", &dir) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("no usable TPM signer ({e}); skipping");
+            return;
+        },
+    };
+
+    let pubkey = signer.public_key().await.expect("public_key");
+    assert_eq!(pubkey.len(), 65);
+    let message = b"PluginTpmSigner stage-B hardware validation";
+    let sig = signer.sign(message).await.expect("sign");
+
+    let vk = p256::ecdsa::VerifyingKey::from_sec1_bytes(&pubkey).unwrap();
+    let signature = p256::ecdsa::Signature::from_slice(&sig).unwrap();
+    vk.verify(message, &signature).expect("signature verifies");
+
+    // Re-open the SAME alias: must load the persisted blob and reproduce the same
+    // public key (no silent re-mint, #134) — and still sign verifiably.
+    drop(signer);
+    let reopened = PluginTpmSigner::open("fed-ecdsa", &dir).expect("re-open");
+    let pubkey2 = reopened.public_key().await.expect("public_key 2");
+    assert_eq!(
+        pubkey, pubkey2,
+        "re-open must reproduce the same key (#134)"
+    );
+    let sig2 = reopened.sign(message).await.expect("sign 2");
+    vk.verify(message, &p256::ecdsa::Signature::from_slice(&sig2).unwrap())
+        .expect("re-opened signer signs verifiably under the same key");
+
+    let _ = std::fs::remove_dir_all(&dir);
+    eprintln!("✓ PluginTpmSigner persist + re-open verified on real hardware");
+}


### PR DESCRIPTION
## #141 stage B — `PluginTpmSigner` (`HardwareSigner`) + factory wiring

The `dlopen` counterpart to the link-time `TpmSigner`: an ECDSA P-256 `HardwareSigner` whose key lives in the TPM, driven through the plugin's ABI-v2 signer path (stage A) instead of link-bound `tss-esapi`. The native TPM **signing** path now works on every target that can load the plugin — incl. the wheel + musl — with no `tss-esapi` in the keyring link graph.

### What's here
- `platform::tpm_plugin_signer::PluginTpmSigner` implements the full `HardwareSigner` surface (EcdsaP256 / TpmFirmware, public_key, sign, generate_key idempotent, key_exists, delete_key, storage_descriptor).
- **Persistence:** `signer_create` returns a TPM-wrapped blob (private half sealed to this TPM), so it stores as a plain `{alias}.tpmplugin_signer` file — same at-rest model as the link-time `TpmSigner`'s `.tpm`.
- **Re-open discipline (#134):** a present blob that won't load on THIS TPM → error, never a silent re-mint.
- **Attestation:** TPM attestation with `quote: None` (honest — the quote/EK-cert port is stage C). NOT a software attestation, so consumers see TPM custody without an over-claimed quote.
- **Factory:** `create_hardware_signer` tries the plugin signer opportunistically — but ONLY where the link-time `TpmSigner` arm won't (not a gnu-linux/windows `--features tpm` build), so existing link-tpm deployments keep their `.tpm` key; the plugin covers the wheel/musl/tpm-less builds. Gated by the plugin's own `available()`.

### Hardware-validated ✅
On a real `/dev/tpmrm0` (ignore-gated test): open → public_key → sign → p256 verify, AND a second `open` of the same alias **reproduces the same key** (persist + #134 re-open), still signing verifiably.

### Verification
- keyring lib **78** green (default **74**); clippy clean on default + tpm-plugin; stub in target/debug

### Next (#141)
- stage C: quote/attestation port (real `quote: Some(...)` + EK cert)
- stage D: default flip → delete the link-time `tpm`/`tss-esapi` dep from the keyring

🤖 Generated with [Claude Code](https://claude.com/claude-code)
