### PR TITLE
feat(tpm): #141 stage C — quote/attestation over the plugin ABI v3

### DIFF
--- a/src/ciris-keyring/src/platform/tpm_plugin_signer.rs
+++ b/src/ciris-keyring/src/platform/tpm_plugin_signer.rs
@@ -22,10 +22,12 @@
 //!
 //! ## Attestation
 //!
-//! Stage B reports a [`HardwareType::TpmFirmware`] attestation with **no quote**
-//! (`quote: None`) — honest: the signing key is TPM-held, but the quote /
-//! EK-cert path is the stage-C port. It is **not** a software attestation, so
-//! consumers see TPM custody without an over-claimed quote.
+//! `attestation_with_nonce` produces a real PCR 0-7 quote bound to the caller's
+//! nonce plus the EK certificate, via the plugin's ABI-v3 quote path (#141 stage
+//! C) under a lazily-provisioned restricted attestation key. If the plugin/TPM
+//! can't quote it degrades to a no-quote [`HardwareType::TpmFirmware`]
+//! attestation — honest, never an over-claimed quote and never a *software*
+//! attestation.
 
 #![cfg(feature = "tpm-plugin")]
 
@@ -45,6 +47,9 @@ use crate::types::{
 pub struct PluginTpmSigner {
     alias: String,
     blob_path: PathBuf,
+    /// Where the restricted attestation-key blob lives (provisioned lazily on the
+    /// first attestation-with-quote).
+    ak_blob_path: PathBuf,
     plugin: TpmPlugin,
     /// The TPM-wrapped key blob (private half sealed to this TPM).
     key_blob: Vec<u8>,
@@ -87,6 +92,7 @@ impl PluginTpmSigner {
             reason: format!("create storage dir: {e}"),
         })?;
         let blob_path = storage_dir.join(format!("{alias}.tpmplugin_signer"));
+        let ak_blob_path = storage_dir.join(format!("{alias}.tpmplugin_ak"));
 
         let key_blob = if blob_path.exists() {
             std::fs::read(&blob_path).map_err(|e| KeyringError::StorageFailed {
@@ -106,10 +112,79 @@ impl PluginTpmSigner {
         Ok(Self {
             alias,
             blob_path,
+            ak_blob_path,
             plugin,
             key_blob,
             public_key,
             lock: Mutex::new(()),
+        })
+    }
+
+    /// Load-or-create the restricted attestation key blob (re-open discipline:
+    /// a present-but-unloadable AK is re-minted — unlike the signing key, the AK
+    /// carries no identity, only attests current PCRs, so a fresh one is safe).
+    fn ensure_ak_blob(&self) -> Result<Vec<u8>, KeyringError> {
+        if self.ak_blob_path.exists() {
+            if let Ok(blob) = std::fs::read(&self.ak_blob_path) {
+                // Validate it loads on this TPM; if not, fall through to re-create.
+                if self.plugin.quote(&blob, &[0u8; 16]).is_ok() {
+                    return Ok(blob);
+                }
+            }
+        }
+        let blob = self.plugin.ak_create()?;
+        write_atomic(&self.ak_blob_path, &blob)?;
+        Ok(blob)
+    }
+
+    /// Build a full TPM attestation with a PCR quote bound to `nonce`, falling
+    /// back to a no-quote TPM attestation if the quote path is unavailable.
+    fn attest(&self, nonce: Option<&[u8]>) -> PlatformAttestation {
+        use rand::RngCore;
+
+        if self.plugin.quote_supported() {
+            let mut random = [0u8; 32];
+            let nonce: &[u8] = match nonce {
+                Some(n) => n,
+                None => {
+                    rand::rngs::OsRng.fill_bytes(&mut random);
+                    &random
+                },
+            };
+            // Serialize TPM access across AK provisioning + quote + EK read.
+            let _guard = self.lock.lock();
+            if let Ok(ak_blob) = self.ensure_ak_blob() {
+                if let Ok(q) = self.plugin.quote(&ak_blob, nonce) {
+                    let ek_cert = self.plugin.ek_certificate().ok();
+                    return PlatformAttestation::Tpm(TpmAttestation {
+                        tpm_version: "2.0".to_string(),
+                        manufacturer: "unknown".to_string(),
+                        discrete: false,
+                        quote: Some(crate::types::TpmQuoteData {
+                            quoted: q.quoted,
+                            signature: q.signature,
+                            pcr_selection: q.pcr_selection,
+                            qualifying_data: nonce.to_vec(),
+                            pcr_values: None,
+                            timestamp: std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .map(|d| d.as_secs())
+                                .unwrap_or(0),
+                        }),
+                        ek_cert,
+                        ak_public_key: Some(q.ak_public_key),
+                    });
+                }
+            }
+        }
+        // No quote path / quote failed → honest no-quote TPM attestation.
+        PlatformAttestation::Tpm(TpmAttestation {
+            tpm_version: "2.0".to_string(),
+            manufacturer: "unknown".to_string(),
+            discrete: false,
+            quote: None,
+            ek_cert: None,
+            ak_public_key: None,
         })
     }
 }
@@ -149,17 +224,17 @@ impl HardwareSigner for PluginTpmSigner {
     }
 
     async fn attestation(&self) -> Result<PlatformAttestation, KeyringError> {
-        // Stage B: TPM-held signing key, but the quote/EK port is stage C — so
-        // report a TPM attestation with no quote (honest, not over-claimed, and
-        // NOT a software attestation).
-        Ok(PlatformAttestation::Tpm(TpmAttestation {
-            tpm_version: "2.0".to_string(),
-            manufacturer: "unknown".to_string(),
-            discrete: false,
-            quote: None,
-            ek_cert: None,
-            ak_public_key: None,
-        }))
+        Ok(self.attest(None))
+    }
+
+    async fn attestation_with_nonce(
+        &self,
+        nonce: Option<&[u8]>,
+    ) -> Result<PlatformAttestation, KeyringError> {
+        // Stage C: a real PCR 0-7 quote bound to `nonce` + the EK cert, via the
+        // plugin's ABI-v3 quote path. Degrades to a no-quote TPM attestation if
+        // the plugin/TPM can't quote (honest, never a software attestation).
+        Ok(self.attest(nonce))
     }
 
     async fn generate_key(&self, _config: &KeyGenConfig) -> Result<(), KeyringError> {

--- a/src/ciris-keyring/src/tpm_plugin.rs
+++ b/src/ciris-keyring/src/tpm_plugin.rs
@@ -40,7 +40,7 @@ const MIN_ABI_VERSION: u32 = 1;
 /// client accepts any version in `[MIN, CURRENT]` and resolves newer ops lazily
 /// (a v1 plugin simply lacks the signer symbols → those methods fail-closed); it
 /// refuses a version `> CURRENT` it can't reason about (fail-closed = "no TPM").
-const CURRENT_ABI_VERSION: u32 = 2;
+const CURRENT_ABI_VERSION: u32 = 3;
 
 /// Plugin C ABI return codes (mirror `ciris-tpm-plugin`).
 const CIRIS_TPM_OK: i32 = 0;
@@ -65,6 +65,35 @@ fn not_supported(reason: impl Into<String>) -> KeyringError {
     KeyringError::NotSupported {
         operation: reason.into(),
     }
+}
+
+/// Split the plugin's `u32_le(len)‖bytes` × 4 quote framing into a
+/// [`PluginQuote`]. Mirrors the plugin's `frame_fields`.
+fn parse_quote(framed: &[u8]) -> Result<PluginQuote, KeyringError> {
+    let mut fields = Vec::with_capacity(4);
+    let mut i = 0usize;
+    while i + 4 <= framed.len() {
+        let len =
+            u32::from_le_bytes([framed[i], framed[i + 1], framed[i + 2], framed[i + 3]]) as usize;
+        i += 4;
+        if i + len > framed.len() {
+            return Err(err("ciris-tpm-plugin quote framing truncated"));
+        }
+        fields.push(framed[i..i + len].to_vec());
+        i += len;
+    }
+    if fields.len() != 4 || i != framed.len() {
+        return Err(err(
+            "ciris-tpm-plugin quote framing malformed (expected 4 fields)",
+        ));
+    }
+    let mut it = fields.into_iter();
+    Ok(PluginQuote {
+        quoted: it.next().unwrap(),
+        signature: it.next().unwrap(),
+        pcr_selection: it.next().unwrap(),
+        ak_public_key: it.next().unwrap(),
+    })
 }
 
 /// The dylib base name for the current platform.
@@ -106,7 +135,25 @@ pub struct TpmPlugin {
     signer_create: Option<CreateFn>,
     signer_public: Option<BlobOpFn>,
     signer_sign: Option<SignFn>,
+    // Quote/attestation path (ABI v3): None on a v1/v2 plugin.
+    ak_create: Option<CreateFn>,
+    // `quote` has the same (in, in, out) signature as `signer_sign`.
+    quote: Option<SignFn>,
+    ek_certificate: Option<CreateFn>,
     free: FreeFn,
+}
+
+/// A parsed TPM quote from [`TpmPlugin::quote`].
+#[derive(Debug, Clone)]
+pub struct PluginQuote {
+    /// The marshalled `TPMS_ATTEST` quoted structure.
+    pub quoted: Vec<u8>,
+    /// Raw ECDSA `r ‖ s` over the quote (verify under `ak_public_key`).
+    pub signature: Vec<u8>,
+    /// PCR-selection bitmap (PCRs 0-7 → `0xFF`).
+    pub pcr_selection: Vec<u8>,
+    /// The AK's SEC1-uncompressed public key (`0x04 ‖ X ‖ Y`).
+    pub ak_public_key: Vec<u8>,
 }
 
 impl TpmPlugin {
@@ -186,6 +233,22 @@ impl TpmPlugin {
             (None, None, None)
         };
 
+        // Quote/attestation path (ABI v3): optional. Same all-or-none discipline.
+        let (ak_create, quote, ek_certificate) = if version >= 3 {
+            // SAFETY: a v3 plugin declares all three; copy out the fn pointers.
+            unsafe {
+                let a = lib.get::<CreateFn>(b"ciris_tpm_ak_create\0").ok();
+                let q = lib.get::<SignFn>(b"ciris_tpm_quote\0").ok();
+                let e = lib.get::<CreateFn>(b"ciris_tpm_ek_certificate\0").ok();
+                match (a, q, e) {
+                    (Some(a), Some(q), Some(e)) => (Some(*a), Some(*q), Some(*e)),
+                    _ => (None, None, None),
+                }
+            }
+        } else {
+            (None, None, None)
+        };
+
         Ok(Self {
             _lib: lib,
             available,
@@ -194,6 +257,9 @@ impl TpmPlugin {
             signer_create,
             signer_public,
             signer_sign,
+            ak_create,
+            quote,
+            ek_certificate,
             free,
         })
     }
@@ -283,6 +349,72 @@ impl TpmPlugin {
             )
         };
         self.finish(rc, out, out_len, "signer_sign")
+    }
+
+    /// Whether this plugin exposes the quote/attestation path (ABI v3).
+    #[must_use]
+    pub fn quote_supported(&self) -> bool {
+        self.ak_create.is_some()
+    }
+
+    /// Create a restricted ECDSA P-256 attestation key (AK); returns its opaque,
+    /// TPM-bound blob (pass to [`Self::quote`]).
+    ///
+    /// # Errors
+    /// [`KeyringError::NotSupported`] on a v1/v2 plugin; [`KeyringError::HardwareError`]
+    /// if the TPM op fails.
+    pub fn ak_create(&self) -> Result<Vec<u8>, KeyringError> {
+        let op = self
+            .ak_create
+            .ok_or_else(|| not_supported("ciris-tpm-plugin has no quote path (ABI < v3)"))?;
+        let mut out: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        // SAFETY: valid out-params.
+        let rc = unsafe { op(&mut out, &mut out_len) };
+        self.finish(rc, out, out_len, "ak_create")
+    }
+
+    /// Quote PCRs 0-7 under `ak_blob`, bound to `nonce`; returns the parsed
+    /// [`PluginQuote`].
+    ///
+    /// # Errors
+    /// [`KeyringError::NotSupported`] on a v1/v2 plugin; [`KeyringError::HardwareError`]
+    /// if the TPM op fails or the framed result can't be parsed.
+    pub fn quote(&self, ak_blob: &[u8], nonce: &[u8]) -> Result<PluginQuote, KeyringError> {
+        let op = self
+            .quote
+            .ok_or_else(|| not_supported("ciris-tpm-plugin has no quote path (ABI < v3)"))?;
+        let mut out: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        // SAFETY: `ak_blob`/`nonce` are valid slices; valid out-params.
+        let rc = unsafe {
+            op(
+                ak_blob.as_ptr(),
+                ak_blob.len(),
+                nonce.as_ptr(),
+                nonce.len(),
+                &mut out,
+                &mut out_len,
+            )
+        };
+        let framed = self.finish(rc, out, out_len, "quote")?;
+        parse_quote(&framed)
+    }
+
+    /// Read the ECC EK certificate (X.509 DER) from NV.
+    ///
+    /// # Errors
+    /// [`KeyringError::NotSupported`] on a v1/v2 plugin; [`KeyringError::HardwareError`]
+    /// if the cert isn't provisioned or the read fails.
+    pub fn ek_certificate(&self) -> Result<Vec<u8>, KeyringError> {
+        let op = self
+            .ek_certificate
+            .ok_or_else(|| not_supported("ciris-tpm-plugin has no quote path (ABI < v3)"))?;
+        let mut out: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        // SAFETY: valid out-params.
+        let rc = unsafe { op(&mut out, &mut out_len) };
+        self.finish(rc, out, out_len, "ek_certificate")
     }
 
     fn blob_op(&self, op: BlobOpFn, input: &[u8], what: &str) -> Result<Vec<u8>, KeyringError> {

--- a/src/ciris-keyring/tests/tpm_plugin_load.rs
+++ b/src/ciris-keyring/tests/tpm_plugin_load.rs
@@ -62,6 +62,18 @@ fn loads_real_plugin_and_completes_abi_handshake() {
         plugin.signer_sign(b"blob", b"data").is_err(),
         "stub signer_sign errors"
     );
+
+    // Quote path (ABI v3): symbols present (v3 plugin), ops fail cleanly w/o a TPM.
+    assert!(
+        plugin.quote_supported(),
+        "v3 plugin must expose the quote path"
+    );
+    assert!(plugin.ak_create().is_err(), "stub ak_create errors");
+    assert!(plugin.quote(b"ak", b"nonce").is_err(), "stub quote errors");
+    assert!(
+        plugin.ek_certificate().is_err(),
+        "stub ek_certificate errors"
+    );
 }
 
 /// Hardware validation of the ABI-v2 signer path (#141) against a **real** TPM.
@@ -173,4 +185,41 @@ async fn plugin_tpm_signer_persists_and_reopens_on_real_tpm() {
 
     let _ = std::fs::remove_dir_all(&dir);
     eprintln!("✓ PluginTpmSigner persist + re-open verified on real hardware");
+}
+
+/// Hardware validation of the ABI-v3 quote path (#141 stage C) against a real
+/// TPM: create a restricted AK, quote PCRs 0-7 bound to a nonce, and confirm the
+/// quote signature verifies under the AK's exported public key. `#[ignore]`d.
+#[test]
+#[ignore = "requires a real TPM + the `real` plugin via CIRIS_TPM_PLUGIN"]
+fn quote_verifies_under_ak_pubkey_on_real_tpm() {
+    use p256::ecdsa::signature::Verifier;
+
+    let path = std::env::var_os("CIRIS_TPM_PLUGIN")
+        .or_else(|| built_plugin().map(Into::into))
+        .expect("set CIRIS_TPM_PLUGIN to a `real` plugin .so");
+    let plugin = TpmPlugin::load_from(&path).expect("plugin loads");
+    if !plugin.available() {
+        eprintln!("no usable TPM; skipping quote validation");
+        return;
+    }
+
+    let ak_blob = plugin.ak_create().expect("create AK");
+    let nonce = [0x5au8; 32];
+    let q = plugin.quote(&ak_blob, &nonce).expect("quote");
+
+    assert_eq!(q.ak_public_key.len(), 65, "SEC1 AK pubkey");
+    assert!(!q.quoted.is_empty(), "TPMS_ATTEST present");
+    assert_eq!(q.signature.len(), 64, "raw r||s");
+    assert_eq!(q.pcr_selection, vec![0xFF], "PCRs 0-7 selected");
+
+    // The TPM signs SHA-256(TPMS_ATTEST) with the restricted AK. p256's
+    // `verify(msg, sig)` hashes the message with SHA-256, so verifying over the
+    // marshalled `quoted` is the right check.
+    let vk = p256::ecdsa::VerifyingKey::from_sec1_bytes(&q.ak_public_key).expect("AK pubkey");
+    let sig = p256::ecdsa::Signature::from_slice(&q.signature).expect("r||s");
+    vk.verify(&q.quoted, &sig)
+        .expect("quote signature must verify under the AK public key");
+
+    eprintln!("✓ TPM quote verified under the AK public key on real hardware");
 }

--- a/src/ciris-tpm-plugin/src/backend.rs
+++ b/src/ciris-tpm-plugin/src/backend.rs
@@ -17,23 +17,26 @@
 mod imp {
     use tss_esapi::{
         attributes::ObjectAttributesBuilder,
-        handles::KeyHandle,
+        handles::{KeyHandle, NvIndexHandle, TpmHandle},
         interface_types::{
             algorithm::{HashingAlgorithm, PublicAlgorithm},
             ecc::EccCurve,
             key_bits::AesKeyBits,
-            resource_handles::Hierarchy,
+            resource_handles::{Hierarchy, NvAuth},
         },
         structures::{
-            Digest, EccPoint, EccScheme, HashScheme, HashcheckTicket, KeyDerivationFunctionScheme,
-            KeyedHashScheme, Private, Public, PublicBuilder, PublicEccParametersBuilder,
-            PublicKeyedHashParameters, SensitiveData, Signature, SignatureScheme,
-            SymmetricDefinitionObject,
+            Data, Digest, EccPoint, EccScheme, HashScheme, HashcheckTicket,
+            KeyDerivationFunctionScheme, KeyedHashScheme, PcrSelectionListBuilder, PcrSlot,
+            Private, Public, PublicBuilder, PublicEccParametersBuilder, PublicKeyedHashParameters,
+            SensitiveData, Signature, SignatureScheme, SymmetricDefinitionObject,
         },
         tcti_ldr::TctiNameConf,
         traits::{Marshall, UnMarshall},
         Context,
     };
+
+    /// ECC EK certificate NV index (TCG spec; ECC P-256 EK).
+    const ECC_EK_CERT_NV_INDEX: u32 = 0x01C0_000A;
 
     /// Open an ESYS context over the platform TCTI (Linux device / Windows TBS).
     /// Ported from `ciris_keyring::platform::tpm::create_context`.
@@ -382,6 +385,179 @@ mod imp {
         }
         out.extend(&bytes[bytes.len().saturating_sub(32)..]);
     }
+
+    // ----------------------------------------------------------------------
+    // Quote/attestation path (#141, ABI v3): a *restricted* ECDSA P-256
+    // attestation key (AK) under the SRK (quotes only TPM-generated data), a
+    // PCR 0-7 quote bound to a caller nonce, and the EK certificate from NV.
+    // Faithful port of `ciris_keyring::platform::tpm::{create_attestation_key,
+    // generate_quote, read_ek_certificate}`. Stateless: the keyring owns the AK
+    // blob, the plugin loads it transiently.
+    // ----------------------------------------------------------------------
+
+    /// Create a *restricted* ECDSA P-256 attestation key (AK) under the SRK and
+    /// return its persistable blob (same framing as the signer key).
+    pub fn ak_create() -> Result<Vec<u8>, String> {
+        let mut context = create_context()?;
+        let primary = get_or_create_primary(&mut context)?;
+
+        let object_attributes = ObjectAttributesBuilder::new()
+            .with_restricted(true)
+            .with_user_with_auth(true)
+            .with_sign_encrypt(true)
+            .with_decrypt(false)
+            .with_fixed_tpm(true)
+            .with_fixed_parent(true)
+            .with_sensitive_data_origin(true)
+            .build()
+            .map_err(|e| format!("ak attrs: {e}"))?;
+
+        let ecc_params = PublicEccParametersBuilder::new()
+            .with_symmetric(SymmetricDefinitionObject::Null)
+            .with_ecc_scheme(EccScheme::EcDsa(HashScheme::new(HashingAlgorithm::Sha256)))
+            .with_curve(EccCurve::NistP256)
+            .with_key_derivation_function_scheme(KeyDerivationFunctionScheme::Null)
+            .with_is_signing_key(true)
+            .with_is_decryption_key(false)
+            .with_restricted(true)
+            .build()
+            .map_err(|e| format!("ak ecc params: {e}"))?;
+
+        let ak_public = PublicBuilder::new()
+            .with_public_algorithm(PublicAlgorithm::Ecc)
+            .with_name_hashing_algorithm(HashingAlgorithm::Sha256)
+            .with_object_attributes(object_attributes)
+            .with_ecc_parameters(ecc_params)
+            .with_ecc_unique_identifier(EccPoint::default())
+            .build()
+            .map_err(|e| format!("ak public: {e}"))?;
+
+        let result = context
+            .execute_with_nullauth_session(|ctx| {
+                ctx.create(primary, ak_public.clone(), None, None, None, None)
+            })
+            .map_err(|e| format!("TPM2_Create (ak): {e}"))?;
+
+        let private_blob = result.out_private.to_vec();
+        let public_blob = result
+            .out_public
+            .marshall()
+            .map_err(|e| format!("marshall ak public: {e}"))?;
+        let _ = context.flush_context(primary.into());
+
+        frame_blob(private_blob, public_blob)
+    }
+
+    /// Quote PCRs 0-7 (SHA-256) under the AK, bound to `nonce` (qualifying data).
+    /// Returns the framed `quoted ‖ signature ‖ pcr_selection ‖ ak_pubkey`
+    /// (each `u32_le`-length-prefixed) — everything a verifier needs.
+    pub fn quote(ak_blob: &[u8], nonce: &[u8]) -> Result<Vec<u8>, String> {
+        let (private, public) = parse_blob(ak_blob)?;
+        let mut context = create_context()?;
+        let primary = get_or_create_primary(&mut context)?;
+        let ak = context
+            .execute_with_nullauth_session(|ctx| ctx.load(primary, private, public))
+            .map_err(|e| format!("TPM2_Load (ak, wrong TPM?): {e}"))?;
+
+        let ak_pub = {
+            let (p, _, _) = context
+                .execute_without_session(|ctx| ctx.read_public(ak))
+                .map_err(|e| format!("read_public (ak): {e}"))?;
+            extract_public_key(&p)?
+        };
+
+        let qualifying_data = Data::try_from(nonce.to_vec())
+            .map_err(|e| format!("qualifying data (nonce too long?): {e}"))?;
+
+        let pcr_selection = PcrSelectionListBuilder::new()
+            .with_selection(
+                HashingAlgorithm::Sha256,
+                &[
+                    PcrSlot::Slot0,
+                    PcrSlot::Slot1,
+                    PcrSlot::Slot2,
+                    PcrSlot::Slot3,
+                    PcrSlot::Slot4,
+                    PcrSlot::Slot5,
+                    PcrSlot::Slot6,
+                    PcrSlot::Slot7,
+                ],
+            )
+            .build()
+            .map_err(|e| format!("pcr selection: {e}"))?;
+
+        let (attest, signature) = context
+            .execute_with_nullauth_session(|ctx| {
+                ctx.quote(
+                    ak,
+                    qualifying_data.clone(),
+                    SignatureScheme::EcDsa {
+                        hash_scheme: HashScheme::new(HashingAlgorithm::Sha256),
+                    },
+                    pcr_selection.clone(),
+                )
+            })
+            .map_err(|e| format!("TPM2_Quote: {e}"))?;
+        let _ = context.flush_context(ak.into());
+        let _ = context.flush_context(primary.into());
+
+        let quoted = attest
+            .marshall()
+            .map_err(|e| format!("marshall attest: {e}"))?;
+        let sig = extract_ecdsa_signature(&signature)?;
+        // PCRs 0-7 selected → bitmap 0xFF (matches the link-time backend).
+        let pcr_sel = vec![0xFFu8];
+
+        Ok(frame_fields(&[&quoted, &sig, &pcr_sel, &ak_pub]))
+    }
+
+    /// Read the ECC EK certificate (X.509 DER) from NV. Errs if not provisioned.
+    pub fn ek_certificate() -> Result<Vec<u8>, String> {
+        let mut context = create_context()?;
+        let tpm_handle = TpmHandle::NvIndex(
+            ECC_EK_CERT_NV_INDEX
+                .try_into()
+                .map_err(|e| format!("invalid NV index: {e:?}"))?,
+        );
+        let object_handle = context
+            .execute_without_session(|ctx| ctx.tr_from_tpm_public(tpm_handle))
+            .map_err(|e| format!("EK cert NV index not accessible (not provisioned?): {e}"))?;
+        let nv_index_handle = NvIndexHandle::from(object_handle);
+
+        let (nv_public, _name) = context
+            .execute_without_session(|ctx| ctx.nv_read_public(nv_index_handle))
+            .map_err(|e| format!("EK cert NV read public: {e}"))?;
+        let cert_size = nv_public.data_size() as u16;
+        if cert_size == 0 {
+            return Err("EK certificate NV area is empty".into());
+        }
+
+        let mut cert = Vec::with_capacity(cert_size as usize);
+        let mut offset = 0u16;
+        const MAX_NV_READ: u16 = 1024;
+        while offset < cert_size {
+            let read_size = std::cmp::min(MAX_NV_READ, cert_size.saturating_sub(offset));
+            let chunk = context
+                .execute_with_nullauth_session(|ctx| {
+                    ctx.nv_read(NvAuth::Owner, nv_index_handle, read_size, offset)
+                })
+                .map_err(|e| format!("NV read at offset {offset}: {e}"))?;
+            cert.extend_from_slice(&chunk);
+            offset += read_size;
+        }
+        Ok(cert)
+    }
+
+    /// Length-prefix each field (`u32_le(len) ‖ bytes`) and concatenate — the
+    /// quote wire framing the keyring client splits back apart.
+    fn frame_fields(fields: &[&[u8]]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for f in fields {
+            out.extend_from_slice(&(f.len() as u32).to_le_bytes());
+            out.extend_from_slice(f);
+        }
+        out
+    }
 }
 
 #[cfg(not(all(
@@ -407,6 +583,18 @@ mod imp {
     pub fn signer_sign(_blob: &[u8], _data: &[u8]) -> Result<Vec<u8>, String> {
         Err("ciris-tpm-plugin built without the `real` backend".to_string())
     }
+    pub fn ak_create() -> Result<Vec<u8>, String> {
+        Err("ciris-tpm-plugin built without the `real` backend".to_string())
+    }
+    pub fn quote(_ak_blob: &[u8], _nonce: &[u8]) -> Result<Vec<u8>, String> {
+        Err("ciris-tpm-plugin built without the `real` backend".to_string())
+    }
+    pub fn ek_certificate() -> Result<Vec<u8>, String> {
+        Err("ciris-tpm-plugin built without the `real` backend".to_string())
+    }
 }
 
-pub use imp::{available, seal, signer_create, signer_public, signer_sign, unseal};
+pub use imp::{
+    ak_create, available, ek_certificate, quote, seal, signer_create, signer_public, signer_sign,
+    unseal,
+};

--- a/src/ciris-tpm-plugin/src/lib.rs
+++ b/src/ciris-tpm-plugin/src/lib.rs
@@ -47,7 +47,9 @@
 /// - **v1:** `available` / `seal` / `unseal` / `free`.
 /// - **v2 (#141):** adds the signer path — `signer_create` / `signer_public` /
 ///   `signer_sign` (ECDSA P-256, stateless blob-based).
-pub const CIRIS_TPM_ABI_VERSION: u32 = 2;
+/// - **v3 (#141):** adds the quote/attestation path — `ak_create` (restricted
+///   AK) / `quote` (PCR 0-7, nonce-bound) / `ek_certificate`.
+pub const CIRIS_TPM_ABI_VERSION: u32 = 3;
 
 /// Operation succeeded.
 pub const CIRIS_TPM_OK: i32 = 0;
@@ -246,6 +248,92 @@ pub unsafe extern "C" fn ciris_tpm_signer_sign(
         },
         Err(e) => {
             tracing::error!("ciris_tpm_signer_sign: {e}");
+            CIRIS_TPM_ERROR
+        },
+    }
+}
+
+/// Create a restricted ECDSA P-256 attestation key (AK) in the TPM → its
+/// persistable blob in `out`/`out_len` (ABI v3, #141). The AK quotes only
+/// TPM-generated data; pass its blob to [`ciris_tpm_quote`].
+///
+/// # Safety
+/// `out`/`out_len` valid; the returned buffer is freed via [`ciris_tpm_free`].
+#[no_mangle]
+pub unsafe extern "C" fn ciris_tpm_ak_create(out: *mut *mut u8, out_len: *mut usize) -> i32 {
+    if out.is_null() || out_len.is_null() {
+        return CIRIS_TPM_ERROR;
+    }
+    match backend::ak_create() {
+        Ok(blob) => {
+            emit(blob, out, out_len);
+            CIRIS_TPM_OK
+        },
+        Err(e) => {
+            tracing::error!("ciris_tpm_ak_create: {e}");
+            CIRIS_TPM_ERROR
+        },
+    }
+}
+
+/// Quote PCRs 0-7 under the AK `ak_blob`, bound to `nonce` → the framed quote
+/// (`quoted ‖ signature ‖ pcr_selection ‖ ak_pubkey`, each `u32_le`-prefixed) in
+/// `out`/`out_len`.
+///
+/// # Safety
+/// `ak_blob` valid for `ak_blob_len`; `nonce` valid for `nonce_len` (or null iff
+/// `nonce_len == 0`); `out`/`out_len` valid. Buffer freed via [`ciris_tpm_free`].
+#[no_mangle]
+pub unsafe extern "C" fn ciris_tpm_quote(
+    ak_blob: *const u8,
+    ak_blob_len: usize,
+    nonce: *const u8,
+    nonce_len: usize,
+    out: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
+    if ak_blob.is_null()
+        || out.is_null()
+        || out_len.is_null()
+        || (nonce.is_null() && nonce_len != 0)
+    {
+        return CIRIS_TPM_ERROR;
+    }
+    let ak_blob = std::slice::from_raw_parts(ak_blob, ak_blob_len);
+    let nonce = if nonce_len == 0 {
+        &[][..]
+    } else {
+        std::slice::from_raw_parts(nonce, nonce_len)
+    };
+    match backend::quote(ak_blob, nonce) {
+        Ok(q) => {
+            emit(q, out, out_len);
+            CIRIS_TPM_OK
+        },
+        Err(e) => {
+            tracing::error!("ciris_tpm_quote: {e}");
+            CIRIS_TPM_ERROR
+        },
+    }
+}
+
+/// Read the ECC EK certificate (X.509 DER) from NV → `out`/`out_len`. Returns
+/// [`CIRIS_TPM_ERROR`] if the EK cert isn't provisioned.
+///
+/// # Safety
+/// `out`/`out_len` valid; the returned buffer is freed via [`ciris_tpm_free`].
+#[no_mangle]
+pub unsafe extern "C" fn ciris_tpm_ek_certificate(out: *mut *mut u8, out_len: *mut usize) -> i32 {
+    if out.is_null() || out_len.is_null() {
+        return CIRIS_TPM_ERROR;
+    }
+    match backend::ek_certificate() {
+        Ok(cert) => {
+            emit(cert, out, out_len);
+            CIRIS_TPM_OK
+        },
+        Err(e) => {
+            tracing::error!("ciris_tpm_ek_certificate: {e}");
             CIRIS_TPM_ERROR
         },
     }


### PR DESCRIPTION
## #141 stage C — quote/attestation over the plugin ABI (v3)

Ports the **last** tss-esapi consumer (the quote/attestation path) into the plugin. The keyring's whole TPM surface — seal/unseal (v7.6.0), signer (stage A/B), and now quote — runs through the `dlopen` plugin with no tss-esapi in its link graph. **Stage D can now delete the link-time `tpm` feature.**

### Plugin (`ciris-tpm-plugin`), ABI v3 (additive)
- `ciris_tpm_ak_create` → restricted ECDSA P-256 attestation key (AK) under the SRK (quotes only TPM-generated data)
- `ciris_tpm_quote(ak_blob, nonce)` → PCR 0-7 quote bound to the nonce, framed `quoted ‖ signature ‖ pcr_selection ‖ ak_pubkey` (each `u32_le`-prefixed)
- `ciris_tpm_ek_certificate` → ECC EK cert (X.509 DER) from NV

Faithful port of `platform/tpm::{create_attestation_key, generate_quote, read_ek_certificate}`. Pure (no I/O; keyring owns the AK blob).

### Keyring client
- ABI range now **[v1, v3]**; v3 symbols resolve lazily (`quote_supported()`). `TpmPlugin::{ak_create, quote -> PluginQuote, ek_certificate}`; `parse_quote` splits the framed fields.
- `PluginTpmSigner::attestation_with_nonce` now returns a **real** `TpmAttestation { quote: Some(PCR 0-7, nonce-bound), ek_cert, ak_public_key }` via a lazily-provisioned AK (`{alias}.tpmplugin_ak`). Degrades to the no-quote TPM attestation if the plugin/TPM can't quote — honest, never software.

### Hardware-validated ✅
On a real `/dev/tpmrm0`: `ak_create → quote(nonce)` and the quote signature **verifies under the AK's exported public key** (AK pubkey 65 B SEC1, sig 64 B r‖s, PCRs 0-7 = 0xFF). All three #141 hardware tests pass together (signer roundtrip, signer persist+reopen, quote verify).

### Verification
- keyring lib **78** (default **74**); plugin **7**; clippy clean on stub + real + keyring
- FFI + tpm-plugin still **0 libtss2 DT_NEEDED**

### Next (#141)
- **stage D**: flip the default + **delete** the link-time `tpm`/tss-esapi dep from the keyring; aarch64/Windows plugin builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
