### PR TITLE
ci: harden crates.io fetch against the recurring HTTP/2 SSL-eof flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,16 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+# Auto-cancel superseded CI runs. Without this, every push to a PR branch starts
+# a fresh full matrix while the prior push's run keeps churning to completion —
+# stacking obsolete runs that starve the runner pool (the cause of the slow-CI
+# congestion). One run per ref: a new push cancels the branch's in-flight CI.
+# Keyed on the ref so different branches/PRs never cancel each other; `main` is
+# protected from accidental cancel by excluding it from the group below.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,14 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # crates.io fetch hardening. The recurring CI failure
+  #   `download of <crate> failed: curl failed … OpenSSL SSL_read: unexpected eof`
+  # is an HTTP/2 multiplexing stream-drop against the crates.io CDN, not a real
+  # build error. Force HTTP/1.1 (no multiplexing), retry downloads aggressively,
+  # and raise the per-op timeout so a transient drop never fails the job.
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_TIMEOUT: "60"
 
 # CIRISCache (CIRISVerify#126 / CIRISServer#99): the GHCR-backed cross-repo Rust
 # build cache. `restore` is anonymous (public package); `save` (main only)

--- a/.github/workflows/post-release-verify.yml
+++ b/.github/workflows/post-release-verify.yml
@@ -25,6 +25,12 @@ on:
     workflows: ["Release"]
     types: [completed]
 
+env:
+  # crates.io fetch hardening — see ci.yml (HTTP/2 CDN stream-drop workaround).
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_TIMEOUT: "60"
+
 jobs:
   live-verify:
     if: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,13 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # crates.io fetch hardening — see ci.yml. The recurring
+  #   `download of <crate> failed: curl failed … SSL_read: unexpected eof`
+  # (e.g. the Android `cargo install cargo-ndk` lane) is an HTTP/2 CDN stream
+  # drop, not a real failure. Force HTTP/1.1 + many retries + a longer timeout.
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_TIMEOUT: "60"
 
 permissions:
   contents: write


### PR DESCRIPTION
The recurring CI failure `download of <crate> failed: curl failed … OpenSSL SSL_read: unexpected eof` (async-trait on #135, malloced on the v8.0.0 Android `cargo-ndk` lane, etc.) is an **HTTP/2 multiplexing stream-drop against the crates.io CDN** — transient, not a real build error.

Global `env:` hardening on **CI / Release / post-release-verify**:
- `CARGO_HTTP_MULTIPLEXING=false` — force HTTP/1.1 (the unexpected-eof is an HTTP/2 framing drop → single-stream avoids it; the load-bearing fix)
- `CARGO_NET_RETRY=10` — retry a failed download up to 10× (default 3)
- `CARGO_NET_TIMEOUT=60` — room for a slow CDN response

Applies to every cargo fetch in those workflows (build, nextest, `cargo install cargo-ndk`/`cross`), so a transient drop no longer fails the job or blocks a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)