### PR TITLE
feat(accord): live-quorum Phase 1 step 1 — proposal/participation objects (FSD-004)

### DIFF
--- a/FSD/FSD-004_ACCORD_DECIMATION_RECOVERY.md
+++ b/FSD/FSD-004_ACCORD_DECIMATION_RECOVERY.md
@@ -410,14 +410,19 @@ exist to bound.
 
 ## 12. Implementation phases (when grounded + reviewed)
 
-1. **Phase 0 — ratify — DECISIONS COMPLETE.** Q1 (fire floor = 1), Q5
-   (constitutional grounding — CC 0.3 §4.2.6), **and now Q2 (fixed 72 h window),
-   Q3 (existing safeguards, no duress canary), Q4 (2-of-3 steward co-sign for
-   rebuilds below `|L| = 3`, never full steward custody)** are all resolved by the
-   maintainer — each matching the CC §4.2.6 default, so no new constitutional text
-   is required. **The one remaining gate before Phase 1 code is the threat-model
-   sign-off / adversarial review (≥ #91/#95 rigor).** Q6 (the HF↔RNS relay
-   backbone) is deployment, not verify code.
+1. **Phase 0 — ratify — COMPLETE.** Q1 (fire floor = 1), Q5 (constitutional
+   grounding — CC 0.3 §4.2.6), Q2 (fixed 72 h window), Q3 (existing safeguards, no
+   duress canary), Q4 (2-of-3 steward co-sign for rebuilds below `|L| = 3`, never
+   full steward custody) all resolved by the maintainer — each matching the CC
+   §4.2.6 default, so no new constitutional text is required. **The adversarial
+   review is DONE** — see [`FSD-004_ADVERSARIAL_REVIEW.md`](FSD-004_ADVERSARIAL_REVIEW.md)
+   (four independent red-team passes ≥ #91/#95 rigor). It found no design
+   rejections; its findings are **build obligations folded into Phases 1-3 below**
+   (the participation canonical-bytes preimage, server-clocked window membership,
+   the standing-roster anti-replay anchor, the equivocation gate, `N_min`/removal-
+   continuity, the resumption-threshold asymmetry, reversal expressibility). Q6
+   (the HF↔RNS relay backbone) is deployment, not verify code. **Phase 1 code is
+   now unblocked.**
 2. **Phase 1 — live-quorum tally + roster change.** `accord_proposal` /
    `accord_participation` / `accord_decision` objects + `tally_live_quorum` +
    `verify_membership_change_by_live_quorum`, reusing the membership-change core.

--- a/FSD/FSD-004_ADVERSARIAL_REVIEW.md
+++ b/FSD/FSD-004_ADVERSARIAL_REVIEW.md
@@ -20,6 +20,37 @@ seizure shapes (one-key-quorum, double-seating-via-spare, lifting entrenchment,
 
 ---
 
+## Resolution status — verify-core machinery IMPLEMENTED
+
+The stateless verify-core obligations are built in `ciris_verify_core::accord_live_quorum`
+(`AccordProposal` / `AccordParticipation` / `AccordDecision`, `tally_live_quorum`,
+`verify_fire_by_live_quorum`, `verify_membership_change_by_live_quorum`,
+`verify_resume_by_live_quorum`, `verify_recovery_supersede`, `decisions_equivocate`),
+each tested:
+
+| Finding | Status |
+|---|---|
+| C1 vote/proposal/family/window in the preimage | ✅ implemented + tested |
+| C2 window in signed bytes; `signed_at` advisory (server-arrival is authoritative) | ✅ verify-core part; the arrival clock is Phase-3 server |
+| C3 anti-replay anchor on the standing roster | ✅ |
+| H1 resumption at roster-change threshold, never fire floor | ✅ (one-yes-fires-but-doesn't-un-fire proven) |
+| H2 resumption binds the active halt | ✅ (`HaltMismatch`) |
+| H3 equivocation gate | ✅ (`decisions_equivocate`) |
+| H5 `N_min` + removal-continuity | ✅ |
+| H6 steward backstop (independent set, server-recomputed `\|L\|`) | ✅ |
+| **H7 reversal** | ✅ **bounded steward roll-back** (`verify_recovery_supersede`) — stewards may **restore a known-good logged snapshot, never install a novel roster**; ⚠ **MUST be CC-cross-confirmed** (it bends the entrenchment rule for the captured-roster case) |
+| M1 fire floor pinned to 1 | ✅ |
+| M2 frozen-`L` snapshot | ✅ (`AccordDecision`) |
+| M3 directory-only resolution, dedup by pinned member | ✅ |
+| M5 `family_key_id` bound | ✅ |
+
+**Remaining (Phase 3 — CIRISServer state, not verify-core):** the authoritative
+window/arrival clock (C2), proposal coalescing + rate-limit (H4), the active-halt
+state (H2 enforcement point), the issued-nonce set + signed-proposal origin (M4),
+durable dedup (M6), and the HF↔RNS relay backbone (Q6).
+
+---
+
 ## Severity-ranked findings → Phase-1 obligations
 
 ### CRITICAL

--- a/FSD/FSD-004_ADVERSARIAL_REVIEW.md
+++ b/FSD/FSD-004_ADVERSARIAL_REVIEW.md
@@ -1,0 +1,238 @@
+# FSD-004 Adversarial Review — Accord Live-Quorum (pre-implementation gate)
+
+**Status:** COMPLETE. This review is the threat-model sign-off that FSD-004 §12
+Phase 0 requires before any live-quorum code lands. It red-teams the **design**
+(FSD-004 + the ratified CC §4.2.6 / §4.2.1.3) and the **existing reused
+primitives** (`accord_genesis`, `humanity_accord`, `threshold`). Method: four
+independent red-team passes, each attacking one dimension, then synthesis.
+Rigor target: ≥ the #91/#95 accord work.
+
+**Verdict:** the design is *sound in its constitutional shape* but **under-specified
+at exactly the points an adversary attacks** — the participation preimage, the
+window-membership predicate, and which roster the authorizing quorum binds to.
+None of the findings invalidate the model; all are **concrete build obligations**
+that Phase 1 MUST satisfy. They are listed below as the normative build spec.
+
+The reused primitives (`verify_threshold_signatures` / `verify_founder_quorum`,
+the membership-change invariants) are **correct** and already stop several
+seizure shapes (one-key-quorum, double-seating-via-spare, lifting entrenchment,
+`1/2` split-brain, replay-against-a-different-prior). They are not re-litigated.
+
+---
+
+## Severity-ranked findings → Phase-1 obligations
+
+### CRITICAL
+
+**C1 — `accord_participation` has no canonical-bytes spec; the vote may not be in the signed bytes (vote-flip) and `refers_to` may be a bare nonce (cross-proposal replay).**
+Unlike `Invocation::canonical_bytes` (which binds kind/payload/etc.), the
+proof-of-life-plus-vote object is described only as a JSON object with sibling
+`vote`/`signature` fields and the loose obligation "verifies over the proposal
+nonce." If the implementer signs nonce-only, a relay/server can flip a recorded
+`vote` (no→yes) or replay a benign-proposal participation into a different
+proposal — both keep the honest holder *in* the denominator while counting them
+for the adversary.
+**Obligation:** define `accord_participation` canonical bytes with a dedicated
+domain prefix and **the vote, the full proposal digest, the member id, and the
+window inside the signed preimage**:
+```
+sha256(
+  "ciris.accord_participation.v1\n" ||
+  "family_key_id=" || fkid || "\n" ||
+  "proposal_digest=" || sha256_hex(JCS(accord_proposal)) || "\n" ||
+  "member_id=" || id || "\n" ||
+  "proof_of_life=true\n" ||
+  "vote=" || ("yes"|"no"|"abstain") || "\n" ||
+  "window_until=" || rfc3339 || "\n" ||
+  "signed_at=" || rfc3339
+)
+```
+`tally_live_quorum` MUST recompute these bytes from the *claimed* fields and drop
+(fail-closed) any participation whose recomputed bytes don't verify — so no vote,
+proposal, family, seat, or window can be altered post-signature. `refers_to` is
+the **full proposal digest**, never the bare nonce.
+
+**C2 — The window-membership predicate is undefined; trusting the holder's self-asserted `signed_at` hands the adversary edge-of-window denominator control.**
+`window_until` is proposer-set and `signed_at` is holder-set; neither FSD-004 nor
+CC §4.2.6 says *which clock* decides "within W." A coerced holder backdates
+`signed_at` to slip a late signature inside a closed window; conversely an honest
+HF store-and-forward survivor's late packet is dropped as "outside W."
+**Obligation:** `L` membership is decided by **server-observed arrival time at the
+authoritative tally, against a server-issued, server-clocked nonce window**
+`W = [nonce_issue_time, window_until]`. `signed_at` is **advisory display only and
+MUST NOT gate `L`**. To protect honest survivors against relay latency, arrival is
+stamped at *first ingress to any honest relay/gateway*, not the final server hop;
+the 72 h window exists for exactly this latency budget.
+
+**C3 — The anti-replay / authorization anchor must stay the STANDING pinned roster, never `L`.**
+The existing `verify_membership_change` binds `supersedes.prior_member_key_ids`
+to the standing prior envelope and authorizes at the prior roster's strict
+majority — that is the whole anti-replay guarantee. FSD-004 §7.2's "the only
+substitution is that the authorizing quorum is the live set `L`" is dangerous if
+read as "resolve the authorizing roster + threshold from `L`": `L` is exactly the
+adversary-shrinkable set, so `2·M > |L|` over a censored `|L|=2` lets **2 captured
+keys** install an all-adversary roster.
+**Obligation:** keep two roles strictly separate — (a) `supersedes.prior_member_key_ids`
+anti-replay binds to the **standing pinned roster** (`humanity_accord_genesis()` /
+`federation_keys`), unchanged; (b) `L` only narrows *which signers count*, and
+**only after each participant is proven a subset of that standing roster** via the
+pinned directory. Invariant test: a `supersedes` whose prior set is the live set
+(not the standing roster) is rejected.
+
+### HIGH
+
+**H1 — Resumption (`lifecycle:active`) is currently admitted at the same 2/3 as everything else; the CC §4.2.1.3 "never at the fire floor; at the roster-change threshold + steward backstop" asymmetry is NOT implemented.**
+`verify_invocation` hardcodes threshold `2` for all kinds; `reactivate_lifecycle_reaches_two_of_three`
+even asserts it. *In today's fixed-3-holder model this is benign* (strict-majority
+of 3 = 2 = the roster-change threshold, and the fire-floor-of-1 doesn't exist
+yet). But the moment Phase-1 live-quorum lands the fire floor at 1, resumption
+MUST NOT follow it down.
+**Obligation:** when live-quorum lands, `verify` branches on kind: `LifecycleActive`
+admits at **strict-majority-of-`L` + the `L_floor` steward 2-of-3 co-sign when
+`|L| < 3`**, never the fire floor; the `reactivate_*` test is inverted to assert a
+resumption at the fire floor (or bare 2/3 below the live majority, no steward sig)
+is **rejected**.
+
+**H2 — No "currently-active halt" check on resumption.** `resumes_halt_id` is in
+the signed bytes (stops *re-pointing* one signature — good) but nothing verifies
+it equals the halt actually in force. CC §4.2.1.3: "the substrate MUST reject a
+`lifecycle:active` whose `resumes_halt_id` does not match the currently-active
+CONSTITUTIONAL halt." This is a server-state obligation.
+**Obligation:** the authoritative resumption path takes the active halt id as
+input and rejects any `lifecycle:active` whose `resumes_halt_id != active_halt_id`;
+once halt-X is resumed, X is no longer active, so a later resumption of X fails
+this check regardless of the dedup window. Expose a verify helper that accepts the
+expected active halt; CIRISServer holds the state.
+
+**H3 — Federation split-brain: "authoritative server" is singular in prose, plural in deployment → two valid `L` for one proposal.** Two partitioned servers
+recompute different `L` over the same pinned keys and each emit a valid
+`accord_decision` (a roster seizure on one side, honest on the other). For *fire*
+this is benign (any server that sees a survivor sig fires — correct). For
+*roster change* it's a fork.
+**Obligation:** two `accord_decision`s superseding the **same `prior_family_digest`**
+are a hard **equivocation conflict — both rejected pending steward reconciliation**
+(reuse the §19.1 equivocation-detection shape already in the codebase). The
+`prior_family_digest` MUST be in the *signed* `supersedes`.
+
+**H4 — Proposal re-roll / window-fishing.** A captured holder re-issues the *same*
+roster-change action as fresh proposals (new nonce ⇒ new W) until a window closes
+with only the captured `L`. The existing anti-replay stops replaying a *decided*
+state, not re-proposing against the *current* state. Also a griefing vector
+(honest holders forced to re-prove life on every spam proposal).
+**Obligation:** proposals for the same `(action, prior_family_digest)` **coalesce**
+— participations across concurrent windows for the same prior digest accumulate
+into one tally, so an honest holder who proved life once stays counted. Add a
+per-proposer **rate-limit/cooldown** on roster-change proposals. **Firing stays
+unthrottled** (fail-toward-firing).
+
+**H5 — Removal-under-cover-of-absence + no minimum roster size → shrink-to-seize.**
+The strict-majority gate validates the *new* envelope's self-consistency but has
+no floor on N and no continuity check: an adversary supersedes 21→2 (or 21→1,
+which `2·M>N` passes) by dropping censored honest holders as "not live," yielding
+a tiny adversary roster that — because **fire is floor-1 and never steward-gated**
+— now owns the kill-switch outright.
+**Obligation:** enforce `N_min > 1` (reject a `1/1` rebuild — mirror the existing
+"no `M==1` escape hatch"); **removal of a standing member requires that member to
+be in `L` and vote their own removal, OR the full standing-roster strict majority**
+— never the live-set majority alone. (Resolves FSD-004 Q4's "never to attacker-only"
+floor.)
+
+**H6 — The steward backstop principal is the accord's own attestation root (correlated capture).** CC §4.2.6 roots the small-`L` backstop in the us/eu/apac
+stewards — the *same* keys that cross-attest the holders at admission. Under the
+first-strike threat model the steward HSMs are always-on infrastructure that may
+fall *before* scattered humans, so the backstop can collapse exactly at `|L|<3`.
+**Obligation:** the rebuild-authorizing steward quorum MUST be a **key-independent
+trust domain** from the holder-attestation root (pinned separately), and the
+`|L| < L_floor` trigger MUST be computed on the **server-recomputed `L`**, never the
+bundle-claimed `L` (else the adversary inflates `L≥3` with coerced keys to *escape*
+the steward floor). Flag for CC cross-confirmation that "independent steward floor"
+means key-independent, not merely role-labeled.
+
+**H7 — A seized entrenched roster has no in-protocol reversal path, yet the design relies on "post-hoc reversal."** The only roster-mutation path is authorized by
+the *prior* (now-seized) roster's quorum; entrenchment forbids lifting the flag or
+changing `family_key_id`. So the honest side cannot supersede the adversary's
+roster. The append-only log proves *what happened* but confers no *authority to
+undo it*.
+**Obligation:** make reversal **expressible** before relying on it — an explicit
+recovery-supersede authorized by a body the seized roster does *not* control
+(steward quorum **plus** any honest standing holder who later proves life, binding
+to the standing-roster snapshot at seizure time from the append-only log), or a
+founder/CC-4.5.1 maturity-gate override. **Until that path exists and is tested,
+FSD-004 downgrades its claim to "detectable but not in-protocol reversible."**
+
+### MEDIUM
+
+**M1 — Fire floor must be hard-pinned to 1 in the live-quorum path**, never
+`strict_majority(|L|)` (else inflating `L` with captured keys raises the fire bar —
+a suppression lever). Test: a fire with large `|L|` but one *yes* still fires.
+
+**M2 — Frozen-`L` snapshot in the decision (Enoch-Arden no retroactive recompute).**
+Each `accord_decision` carries the immutable server-attested `L` snapshot + `W`
+bounds; a closed decision's `L` is final. Re-enrollment changes the *standing
+roster going forward*, never a past decision's denominator. Transparency-log it.
+
+**M3 — Holder identity in the preimage + directory-only resolution.** Include
+`member_id` (+ a hash of the Ed25519 pubkey) in the participation preimage; dedup
+`L` by **pinned pubkey**, not the plaintext `member_id` string; resolve signers
+**only** against pinned `federation_keys`, never a bundle-embedded roster.
+
+**M4 — Proposal origin authentication.** `accord_proposal` MUST be **signed by an
+authenticated quorum authority** (CIRISServer steward key or the family) and the
+holder's station + tally MUST verify that signature + that the nonce is one the
+server actually issued (server keeps the issued-nonce set); a participation
+referencing an unknown nonce is rejected fail-closed. A holder MUST NOT sign a
+participation for a proposal whose origin it cannot verify.
+
+**M5 — `family_key_id` in the signed participation preimage** (today the invocation
+preimage also omits it — flagged in `accord_genesis`). Low risk while
+HUMANITY_ACCORD is the only family; bind it now so a participation is
+non-transferable across families by construction. Fold into the same preimage
+spec as C1.
+
+**M6 — Resumption dedup is in-memory/per-process and per-`valid_until`.** Not the
+anti-replay boundary — H2's active-halt state is. Persist dedup on the
+authoritative server or document it as advisory with the active-halt invariant
+load-bearing.
+
+---
+
+## What the existing primitives already guarantee (not re-litigated)
+
+`reject_duplicate_member_keys` / `require_distinct_keys` (one key can't meet
+quorum, one human can't double-seat via a spare); `2·M > N` everywhere (no `1/2`
+split-brain); entrenchment-flag + `family_key_id` immutability on supersede;
+anti-replay bind to the standing prior envelope; per-member signature over
+canonical bytes resolved against the pinned directory. `verify_threshold_signatures`
+verifies over whatever bytes the caller supplies — sound, but it cannot
+compensate for an under-specified preimage (hence C1).
+
+---
+
+## Build sequencing (Phase 1, informed by this review)
+
+1. **Object preimages first (C1, C2, M3, M5):** `accord_proposal` (JCS, signed by an
+   authority, carries `nonce`/`window_until`/`prior_family_digest`),
+   `accord_participation` (the domain-prefixed preimage above), `accord_decision`
+   (frozen `L` snapshot + tally + `prior_family_digest` + steward sigs when
+   `|L|<3`). Server-clocked window membership (C2). Conformance + scope-isolation
+   tests mirroring `lifecycle_scope_is_wire_isolated_from_invoke`.
+2. **`tally_live_quorum` + `verify_membership_change_by_live_quorum` (C3, H5, H6, M1, M2):**
+   anti-replay anchored to the standing roster; `L` ⊆ standing roster; fire floor
+   hard-pinned to 1; roster-change at strict-majority-of-`L`; `N_min>1`;
+   removal-continuity; the server-recomputed `L_floor` steward backstop; frozen-`L`.
+3. **Equivocation + anti-griefing (H3, H4):** conflict on two decisions over one
+   `prior_family_digest`; proposal coalescing + roster-change rate-limit.
+4. **Resumption asymmetry + active-halt (H1, H2):** branch resumption to the
+   roster-change threshold; the active-halt-match verify helper.
+5. **Reversal (H7):** the recovery-supersede path, or the explicit doc downgrade.
+6. **Server + ceremony (Phase 3):** authoritative single-point recompute (or
+   steward-cosigned canonical `L`), holder participation flow, the HF↔RNS gateway
+   backbone (deployment, FSD-004 Q6).
+
+Every verify obligation above is **fail-closed**.
+
+---
+
+*Review conducted pre-implementation per FSD-004 §12 Phase 0. The findings are
+build obligations, not design rejections; the constitutional shape (CC §4.2.6 /
+§4.2.1.3) is upheld. Tracks CIRISVerify#98.*

--- a/src/ciris-verify-core/src/accord_genesis.rs
+++ b/src/ciris-verify-core/src/accord_genesis.rs
@@ -342,7 +342,7 @@ impl std::fmt::Display for AccordGenesisError {
 impl std::error::Error for AccordGenesisError {}
 
 /// Extract the envelope's member `key_id`s in order.
-fn envelope_member_key_ids(envelope: &Value) -> Result<Vec<String>, AccordGenesisError> {
+pub(crate) fn envelope_member_key_ids(envelope: &Value) -> Result<Vec<String>, AccordGenesisError> {
     let members = envelope.get("members").and_then(Value::as_array).ok_or(
         AccordGenesisError::MalformedEnvelope {
             detail: "missing or non-array `members`".to_string(),
@@ -820,6 +820,59 @@ pub fn verify_membership_change(
     prior_quorum_signatures: &[ThresholdSignature],
     directory: &[ThresholdMember],
 ) -> Result<(), AccordGenesisError> {
+    // Steps 1-3: the structural invariants (distinct + strict-majority, distinct
+    // pubkeys/one-seat, entrenchment/identity preserved, and the anti-replay anchor
+    // `supersedes.prior_member_key_ids == prior roster`). Factored out so the
+    // live-quorum path reuses the identical structure (CIRISVerify#98 / FSD-004).
+    validate_membership_change_structure(prior_envelope, new_envelope, directory)?;
+
+    // 4. Authorized by the PRIOR roster's strict-majority quorum (role-agnostic).
+    let prior_roster = roster_from_envelope(prior_envelope, directory)?;
+    let prior_threshold = quorum_threshold_from_envelope(prior_envelope)?;
+    let bytes = accord_family_signing_bytes(new_envelope).map_err(|e| {
+        AccordGenesisError::Canonicalize {
+            detail: e.to_string(),
+        }
+    })?;
+    match verify_threshold_signatures(
+        &bytes,
+        &prior_roster,
+        prior_quorum_signatures,
+        prior_threshold,
+    ) {
+        Ok(_) => Ok(()),
+        Err(ThresholdError::Insufficient { valid, threshold }) => {
+            Err(AccordGenesisError::QuorumNotMet {
+                valid,
+                required: threshold,
+            })
+        },
+        Err(e) => Err(AccordGenesisError::Threshold {
+            detail: format!("{e:?}"),
+        }),
+    }
+}
+
+/// The **structural** invariants of a membership change — everything except the
+/// authorization (who signed). Factored out of [`verify_membership_change`] so the
+/// live-quorum path ([`crate::accord_live_quorum`]) reuses the *exact same*
+/// structure checks while authorizing over the live set `L` instead of the prior
+/// roster's quorum (CIRISVerify#98 / FSD-004 C3).
+///
+/// Validates: the new envelope is well-formed + lists **distinct** members at a
+/// strict-majority `quorum:M/N` (`2·M > N`); the new roster resolves in
+/// `directory` to **distinct pubkeys** (one-key/one-human-one-seat); `family_key_id`
+/// is unchanged and an entrenched prior is not de-entrenched; and
+/// `supersedes.prior_member_key_ids` **equals the actual prior member set** — the
+/// anti-replay anchor, bound to the **prior/standing** roster (never the live set).
+///
+/// # Errors
+/// [`AccordGenesisError`] naming the first failing invariant.
+pub fn validate_membership_change_structure(
+    prior_envelope: &Value,
+    new_envelope: &Value,
+    directory: &[ThresholdMember],
+) -> Result<(), AccordGenesisError> {
     // 1. New envelope well-formed + distinct members + strict-majority M/N.
     let new_ids = envelope_member_key_ids(new_envelope)?;
     {
@@ -872,32 +925,7 @@ pub fn verify_membership_change(
             detail: "supersedes.prior_member_key_ids does not match the prior group".to_string(),
         });
     }
-
-    // 4. Authorized by the PRIOR roster's strict-majority quorum (role-agnostic).
-    let prior_roster = roster_from_envelope(prior_envelope, directory)?;
-    let prior_threshold = quorum_threshold_from_envelope(prior_envelope)?;
-    let bytes = accord_family_signing_bytes(new_envelope).map_err(|e| {
-        AccordGenesisError::Canonicalize {
-            detail: e.to_string(),
-        }
-    })?;
-    match verify_threshold_signatures(
-        &bytes,
-        &prior_roster,
-        prior_quorum_signatures,
-        prior_threshold,
-    ) {
-        Ok(_) => Ok(()),
-        Err(ThresholdError::Insufficient { valid, threshold }) => {
-            Err(AccordGenesisError::QuorumNotMet {
-                valid,
-                required: threshold,
-            })
-        },
-        Err(e) => Err(AccordGenesisError::Threshold {
-            detail: format!("{e:?}"),
-        }),
-    }
+    Ok(())
 }
 
 /// Build an **accord** membership-change envelope (CIRISVerify#95) — the

--- a/src/ciris-verify-core/src/accord_live_quorum.rs
+++ b/src/ciris-verify-core/src/accord_live_quorum.rs
@@ -50,11 +50,19 @@ pub const PARTICIPATION_DOMAIN_PREFIX: &str = "ciris.accord_participation.v1\n";
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AccordAction {
-    /// A live-quorum `CONSTITUTIONAL` fire (tallied at the floor of 1 in step 2).
+    /// A live-quorum `CONSTITUTIONAL` fire — tallied at the floor of 1 (the easy
+    /// end of the bias gradient; a missed fire is terminal).
     Fire,
-    /// A roster grow / shrink / swap (tallied at strict-majority-of-`L` + the
-    /// `L_floor` steward backstop in step 2), carried as a family `supersedes`.
+    /// A roster grow / shrink / swap — tallied at strict-majority-of-`L` + the
+    /// `L_floor` steward backstop (the hard end), carried as a family `supersedes`.
     RosterChange,
+    /// A resumption (un-fire) of the currently-active `CONSTITUTIONAL` halt
+    /// (`accord:lifecycle:active`, CC §4.2.1.3) — tallied at the **roster-change
+    /// threshold**, NEVER the fire floor: un-firing leans hard, because a lone
+    /// coerced/replayed key undoing a legitimate halt is the failure the
+    /// halt-authority exists to prevent (the `fire ≤ roster-change ≤ standing`
+    /// gradient).
+    Resume,
 }
 
 impl AccordAction {
@@ -64,6 +72,7 @@ impl AccordAction {
         match self {
             Self::Fire => "fire",
             Self::RosterChange => "roster_change",
+            Self::Resume => "resume",
         }
     }
 }
@@ -326,6 +335,15 @@ pub enum LiveQuorumError {
         /// The `member_id` that would be removed without consenting/participating.
         member_id: String,
     },
+    /// A resumption does not target the currently-active `CONSTITUTIONAL` halt
+    /// (H2): `proposal.payload_sha256 != sha256(active_halt_id)`. A stockpiled /
+    /// replayed resumption naming a different (e.g. later) halt is rejected.
+    HaltMismatch {
+        /// `sha256(active_halt_id)` — the halt actually in force.
+        expected: String,
+        /// The halt commitment the proposal carried.
+        got: String,
+    },
     /// The hybrid signature did not verify over the recomputed canonical bytes.
     Signature(String),
 }
@@ -377,6 +395,10 @@ impl std::fmt::Display for LiveQuorumError {
             Self::RemovedAbsentMember { member_id } => write!(
                 f,
                 "standing member {member_id} removed without proving life ∉ L (H5)"
+            ),
+            Self::HaltMismatch { expected, got } => write!(
+                f,
+                "resumption payload {got} != active-halt commitment {expected} (H2)"
             ),
             Self::Signature(e) => write!(f, "participation signature invalid: {e}"),
         }
@@ -618,13 +640,34 @@ pub fn verify_membership_change_by_live_quorum(
         }
     }
 
-    // 7. Authorization: strict-majority-of-L + the L_floor steward backstop (H6).
+    // 7. Authorization: the "roster-change tier" — strict-majority-of-L + the
+    //    L_floor steward backstop (H6).
+    let (authorized, used_steward_backstop) =
+        authorize_roster_tier(proposal, &tally, steward_members, steward_signatures);
+
+    Ok(RosterChangeVerdict {
+        authorized,
+        tally,
+        used_steward_backstop,
+    })
+}
+
+/// The **roster-change tier** authorization — the *hard* end of the
+/// `fire ≤ roster-change ≤ standing` bias gradient (CC §4.2.1.3). Requires
+/// strict-majority-of-`L` yes votes, AND — when `|L| < L_FLOOR` — the steward
+/// 2-of-3 backstop over `proposal` (a key-independent steward set, H6), computed
+/// on the **server-recomputed** `|L|` (never a claimed value). Shared by roster
+/// change and resumption (un-fire), which both lean hard — the deliberate
+/// opposite of the fire floor of 1. Returns `(authorized, used_steward_backstop)`.
+fn authorize_roster_tier(
+    proposal: &AccordProposal,
+    tally: &LiveQuorumTally,
+    steward_members: &[ThresholdMember],
+    steward_signatures: &[ThresholdSignature],
+) -> (bool, bool) {
     let majority_met = tally.yes >= crate::accord_genesis::strict_majority(tally.live_count());
     let used_steward_backstop = tally.live_count() < L_FLOOR;
     let steward_ok = if used_steward_backstop {
-        // 2-of-3 (strict majority) of an INDEPENDENT steward set, over the proposal
-        // bytes (which transitively bind the new roster via payload_sha256). The
-        // |L| trigger is the SERVER-recomputed tally, never a claimed value.
         let steward_threshold =
             crate::accord_genesis::strict_majority(steward_members.len().max(1));
         verify_threshold_signatures(
@@ -637,9 +680,70 @@ pub fn verify_membership_change_by_live_quorum(
     } else {
         true
     };
+    (majority_met && steward_ok, used_steward_backstop)
+}
 
-    Ok(RosterChangeVerdict {
-        authorized: majority_met && steward_ok,
+/// The verdict of a live-quorum resumption (un-fire).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResumeVerdict {
+    /// Whether the currently-active halt is resumed (un-fired).
+    pub resumed: bool,
+    /// The frozen tally over `L`.
+    pub tally: LiveQuorumTally,
+    /// Whether `|L| < L_FLOOR` forced the steward backstop (H6).
+    pub used_steward_backstop: bool,
+}
+
+/// Verify a live-quorum **resumption** (un-fire) of the currently-active
+/// `CONSTITUTIONAL` halt — the decimation-mode `accord:lifecycle:active`
+/// (CC §4.2.1.3).
+///
+/// Two obligations beyond a normal tally:
+/// - **H1 (asymmetry):** authorized at the **roster-change threshold**
+///   (`authorize_roster_tier` — strict-majority-of-`L` + the `L_floor` steward
+///   backstop), **never** the fire floor of 1. Un-firing leans hard.
+/// - **H2 (active-halt binding):** the proposal MUST target the halt actually in
+///   force — `proposal.payload_sha256 == sha256(active_halt_id)`. A stockpiled or
+///   replayed resumption naming a *different* (e.g. later) halt is rejected
+///   ([`LiveQuorumError::HaltMismatch`]); once a halt is resumed it is no longer
+///   `active`, so a second resumption of it fails this check (the server holds
+///   the active-halt state).
+///
+/// # Errors
+/// [`LiveQuorumError`] for a wrong action, an active-halt mismatch, or a bad
+/// participation. The yes/no outcome is [`ResumeVerdict::resumed`].
+pub fn verify_resume_by_live_quorum(
+    proposal: &AccordProposal,
+    participations: &[AccordParticipation],
+    standing_roster: &[ThresholdMember],
+    steward_members: &[ThresholdMember],
+    steward_signatures: &[ThresholdSignature],
+    active_halt_id: &str,
+) -> Result<ResumeVerdict, LiveQuorumError> {
+    if proposal.action != AccordAction::Resume {
+        return Err(LiveQuorumError::WrongAction {
+            expected: "resume",
+            got: proposal.action.as_str(),
+        });
+    }
+    // H2: the resumption targets the CURRENTLY-ACTIVE halt.
+    let expected = {
+        let mut h = Sha256::new();
+        h.update(active_halt_id.as_bytes());
+        hex::encode(h.finalize())
+    };
+    if proposal.payload_sha256 != expected {
+        return Err(LiveQuorumError::HaltMismatch {
+            expected,
+            got: proposal.payload_sha256.clone(),
+        });
+    }
+    let tally = tally_live_quorum(proposal, participations, standing_roster)?;
+    // H1: roster-change threshold, NEVER the fire floor.
+    let (authorized, used_steward_backstop) =
+        authorize_roster_tier(proposal, &tally, steward_members, steward_signatures);
+    Ok(ResumeVerdict {
+        resumed: authorized,
         tally,
         used_steward_backstop,
     })
@@ -1362,5 +1466,126 @@ mod tests {
             !decisions_equivocate(&da, &db),
             "different prior digests are sequential states, not a fork"
         );
+    }
+
+    // --- resumption / un-fire (step 5) --------------------------------------
+
+    fn halt_commitment(active_halt_id: &str) -> String {
+        let mut h = Sha256::new();
+        h.update(active_halt_id.as_bytes());
+        hex::encode(h.finalize())
+    }
+
+    fn resume_proposal(active_halt_id: &str) -> AccordProposal {
+        AccordProposal {
+            family_key_id: "humanity-accord".to_string(),
+            action: AccordAction::Resume,
+            nonce: "resume-nonce-XXXXXXXXXXXXXXXXXXXXXXXX".to_string(),
+            window_until: "2026-06-29T00:00:00.000Z".to_string(),
+            prior_family_digest: "a".repeat(64),
+            payload_sha256: halt_commitment(active_halt_id),
+        }
+    }
+
+    #[test]
+    fn resume_requires_majority_not_the_fire_floor() {
+        // H1 — THE asymmetry. In a 3-live set, ONE yes FIRES (floor 1) but does
+        // NOT un-fire (resumption needs strict-majority = 2). Un-firing leans hard.
+        let (hs, dir) = roster_fixture();
+        let halt = "halt-2026-06-26";
+        let prop = resume_proposal(halt);
+        // 1 yes, 2 no → |L|=3, strict-majority(3)=2 NOT met.
+        let parts = vec![
+            participate(&hs[0], &prop, Vote::Yes),
+            participate(&hs[1], &prop, Vote::No),
+            participate(&hs[2], &prop, Vote::No),
+        ];
+        let v = verify_resume_by_live_quorum(&prop, &parts, &dir, &[], &[], halt).unwrap();
+        assert!(
+            !v.resumed,
+            "one yes does not un-fire (the fire-floor-of-1 is NOT used)"
+        );
+
+        // Sanity: the SAME single yes WOULD fire if it were a fire proposal.
+        let mut fire = prop.clone();
+        fire.action = AccordAction::Fire;
+        let fparts = vec![participate(&hs[0], &fire, Vote::Yes)];
+        let fdir = vec![hs[0].member()];
+        assert!(
+            verify_fire_by_live_quorum(&fire, &fparts, &fdir)
+                .unwrap()
+                .fired
+        );
+    }
+
+    #[test]
+    fn resume_authorized_by_live_majority() {
+        let (hs, dir) = roster_fixture();
+        let halt = "halt-2026-06-26";
+        let prop = resume_proposal(halt);
+        let parts: Vec<_> = hs[..3]
+            .iter()
+            .map(|h| participate(h, &prop, Vote::Yes))
+            .collect();
+        let v = verify_resume_by_live_quorum(&prop, &parts, &dir, &[], &[], halt).unwrap();
+        assert!(v.resumed, "strict-majority-of-L yes resumes");
+        assert!(!v.used_steward_backstop);
+    }
+
+    #[test]
+    fn resume_targeting_the_wrong_halt_is_rejected() {
+        // H2: a resumption naming a different (e.g. later/stockpiled) halt fails.
+        let (hs, dir) = roster_fixture();
+        let prop = resume_proposal("halt-OLD"); // payload commits to halt-OLD
+        let parts: Vec<_> = hs[..3]
+            .iter()
+            .map(|h| participate(h, &prop, Vote::Yes))
+            .collect();
+        // but the currently-active halt is a DIFFERENT one.
+        assert!(matches!(
+            verify_resume_by_live_quorum(&prop, &parts, &dir, &[], &[], "halt-CURRENT-different"),
+            Err(LiveQuorumError::HaltMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn resume_below_l_floor_needs_steward_backstop() {
+        // H6 applies to resumption too — |L| < 3 requires the steward co-sign.
+        let (hs, dir) = roster_fixture();
+        let halt = "halt-2026-06-26";
+        let prop = resume_proposal(halt);
+        let parts = vec![
+            participate(&hs[0], &prop, Vote::Yes),
+            participate(&hs[1], &prop, Vote::Yes),
+        ];
+        let stewards: Vec<Holder> = ["S1", "S2", "S3"]
+            .iter()
+            .map(|id| Holder::new(id))
+            .collect();
+        let sm: Vec<ThresholdMember> = stewards.iter().map(Holder::member).collect();
+
+        let v_no = verify_resume_by_live_quorum(&prop, &parts, &dir, &sm, &[], halt).unwrap();
+        assert!(v_no.used_steward_backstop && !v_no.resumed);
+
+        let ss: Vec<ThresholdSignature> = stewards[..2]
+            .iter()
+            .map(|s| s.sign(&prop.canonical_bytes()))
+            .collect();
+        let v_yes = verify_resume_by_live_quorum(&prop, &parts, &dir, &sm, &ss, halt).unwrap();
+        assert!(v_yes.resumed, "|L|<3 + 2-of-3 stewards un-fires");
+    }
+
+    #[test]
+    fn resume_verifier_rejects_a_non_resume_proposal() {
+        let (hs, dir) = roster_fixture();
+        let prop = fire_proposal(); // Fire, not Resume
+        let parts = vec![participate(&hs[0], &prop, Vote::Yes)];
+        assert!(matches!(
+            verify_resume_by_live_quorum(&prop, &parts, &dir, &[], &[], "h"),
+            Err(LiveQuorumError::WrongAction {
+                expected: "resume",
+                ..
+            })
+        ));
     }
 }

--- a/src/ciris-verify-core/src/accord_live_quorum.rs
+++ b/src/ciris-verify-core/src/accord_live_quorum.rs
@@ -344,6 +344,15 @@ pub enum LiveQuorumError {
         /// The halt commitment the proposal carried.
         got: String,
     },
+    /// A steward recovery roll-back (H7) targets a roster that is NOT a known-good
+    /// prior snapshot — stewards may only **restore** a logged honest roster, never
+    /// **install** a novel one (so they can undo a capture but never seize it).
+    RecoveryNotKnownGood {
+        /// The member set the recovery would install.
+        recovered: Vec<String>,
+        /// The server-supplied known-good prior roster it had to match.
+        known_good: Vec<String>,
+    },
     /// The hybrid signature did not verify over the recomputed canonical bytes.
     Signature(String),
 }
@@ -399,6 +408,14 @@ impl std::fmt::Display for LiveQuorumError {
             Self::HaltMismatch { expected, got } => write!(
                 f,
                 "resumption payload {got} != active-halt commitment {expected} (H2)"
+            ),
+            Self::RecoveryNotKnownGood {
+                recovered,
+                known_good,
+            } => write!(
+                f,
+                "recovery roster {recovered:?} is not the known-good snapshot {known_good:?} \
+                 — stewards may restore, never install novel (H7)"
             ),
             Self::Signature(e) => write!(f, "participation signature invalid: {e}"),
         }
@@ -747,6 +764,89 @@ pub fn verify_resume_by_live_quorum(
         tally,
         used_steward_backstop,
     })
+}
+
+/// The verdict of a steward recovery roll-back (H7).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveryVerdict {
+    /// Whether the steward quorum validly authorized the roll-back.
+    pub authorized: bool,
+}
+
+/// Verify a **bounded steward recovery roll-back** (H7) — the *only* path to
+/// reverse a captured, entrenched accord roster.
+///
+/// If an adversary ever wins a takeover (a live-majority roster seizure *and* the
+/// steward backstop), the seized roster is entrenched — only *its* quorum could
+/// change it, so the honest side cannot undo it. This deliberately-bounded
+/// override lets the **steward quorum restore a previously-logged known-good
+/// roster**, so stewards can **undo** a capture but never **seize**:
+///
+/// - **structure:** `recovery_envelope` is a structurally-valid entrenched
+///   supersede of `seized_envelope` (same `family_key_id`, entrenchment preserved,
+///   `supersedes.prior_member_key_ids ==` the seized members — it targets the
+///   specific captured state);
+/// - **bounded to known-good (no seize):** the recovery roster's members MUST
+///   equal `known_good_member_ids` — a roster the **server** supplies from its
+///   append-only log of prior honest decisions. Stewards therefore can only sign
+///   a roster the log already blessed, never a novel one;
+/// - **authority:** the **steward quorum** (strict majority of an independent
+///   steward set), NOT the seized roster's quorum — the captured roster cannot
+///   block its own reversal.
+///
+/// ⚠ This bends the entrenchment "only the roster's own quorum changes it" rule,
+/// deliberately, for the captured-roster case only. It **MUST be cross-confirmed
+/// with the CIRIS Constitution** (CC §4.2 / §4.5.1) before deployment — it grants
+/// the stewards a real (if bounded) override of an entrenched surface.
+///
+/// `directory` is the authoritative `federation_keys` pin set (covering the
+/// seized + recovery members). The "known-good" determination is server policy
+/// (verify-core enforces the binding the server provides; it cannot know history).
+///
+/// # Errors
+/// [`LiveQuorumError`] for a structural violation or a recovery roster that isn't
+/// the known-good snapshot. The yes/no is [`RecoveryVerdict::authorized`].
+#[allow(clippy::too_many_arguments)]
+pub fn verify_recovery_supersede(
+    seized_envelope: &serde_json::Value,
+    recovery_envelope: &serde_json::Value,
+    directory: &[ThresholdMember],
+    known_good_member_ids: &[String],
+    steward_members: &[ThresholdMember],
+    steward_signatures: &[ThresholdSignature],
+) -> Result<RecoveryVerdict, LiveQuorumError> {
+    // 1. Structure: a valid entrenched supersede of the SEIZED roster (the
+    //    anti-replay anchor binds to the seized members — it targets that state).
+    crate::accord_genesis::validate_membership_change_structure(
+        seized_envelope,
+        recovery_envelope,
+        directory,
+    )
+    .map_err(|e| LiveQuorumError::Structure(e.to_string()))?;
+
+    // 2. Bounded: the recovery roster MUST be a known-good prior snapshot — no
+    //    novel roster (stewards restore, never seize).
+    let recovered = crate::accord_genesis::envelope_member_key_ids(recovery_envelope)
+        .map_err(|e| LiveQuorumError::Structure(e.to_string()))?;
+    if recovered != known_good_member_ids {
+        return Err(LiveQuorumError::RecoveryNotKnownGood {
+            recovered,
+            known_good: known_good_member_ids.to_vec(),
+        });
+    }
+
+    // 3. Authority: the steward quorum ONLY (the seized roster can't block).
+    let bytes = crate::accord_genesis::accord_family_signing_bytes(recovery_envelope)
+        .map_err(|e| LiveQuorumError::Structure(e.to_string()))?;
+    let steward_threshold = crate::accord_genesis::strict_majority(steward_members.len().max(1));
+    let authorized = verify_threshold_signatures(
+        &bytes,
+        steward_members,
+        steward_signatures,
+        steward_threshold,
+    )
+    .is_ok();
+    Ok(RecoveryVerdict { authorized })
 }
 
 /// The frozen, server-attested outcome of a live-quorum decision (M2).
@@ -1587,5 +1687,77 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    // --- bounded steward recovery roll-back (step 6, H7) --------------------
+
+    /// (seized roster [X1,X2]) + (honest known-good [A1,B1,C1]) + directory + 3
+    /// stewards. Returns (seized_env, recovery_env, directory, known_good_ids,
+    /// steward_members, steward_holders).
+    fn recovery_fixture() -> (
+        Value,
+        Value,
+        Vec<ThresholdMember>,
+        Vec<String>,
+        Vec<ThresholdMember>,
+        Vec<Holder>,
+    ) {
+        let honest: Vec<Holder> = ["A1", "B1", "C1"]
+            .iter()
+            .map(|id| Holder::new(id))
+            .collect();
+        let captured: Vec<Holder> = ["X1", "X2"].iter().map(|id| Holder::new(id)).collect();
+        let mut dir: Vec<ThresholdMember> = honest.iter().map(Holder::member).collect();
+        dir.extend(captured.iter().map(Holder::member));
+        let seized = family_envelope(&["X1", "X2"]); // the adversary's entrenched roster
+        let known_good = vec!["A1".to_string(), "B1".to_string(), "C1".to_string()];
+        // recovery: restore A1,B1,C1, superseding the seized X1,X2.
+        let recovery = build_membership_change(&seized, &known_good, Role::Founder, true, None);
+        let stewards: Vec<Holder> = ["S1", "S2", "S3"]
+            .iter()
+            .map(|id| Holder::new(id))
+            .collect();
+        let sm: Vec<ThresholdMember> = stewards.iter().map(Holder::member).collect();
+        (seized, recovery, dir, known_good, sm, stewards)
+    }
+
+    #[test]
+    fn steward_quorum_can_roll_back_to_known_good() {
+        let (seized, recovery, dir, kg, sm, stewards) = recovery_fixture();
+        let bytes = accord_family_signing_bytes(&recovery).unwrap();
+        let ss: Vec<ThresholdSignature> = stewards[..2].iter().map(|s| s.sign(&bytes)).collect();
+        let v = verify_recovery_supersede(&seized, &recovery, &dir, &kg, &sm, &ss).unwrap();
+        assert!(v.authorized, "2-of-3 stewards restore a known-good roster");
+    }
+
+    #[test]
+    fn recovery_to_a_novel_roster_is_rejected() {
+        // The seize-prevention: stewards CANNOT install a roster that isn't the
+        // known-good snapshot — even with a full steward quorum.
+        let (seized, _recovery, mut dir, kg, sm, stewards) = recovery_fixture();
+        // adversary-friendly stewards try to install [A1,B1,Z1] instead of [A1,B1,C1].
+        let z = Holder::new("Z1");
+        dir.push(z.member());
+        let novel = build_membership_change(
+            &seized,
+            &["A1", "B1", "Z1"].map(String::from),
+            Role::Founder,
+            true,
+            None,
+        );
+        let bytes = accord_family_signing_bytes(&novel).unwrap();
+        let ss: Vec<ThresholdSignature> = stewards.iter().map(|s| s.sign(&bytes)).collect();
+        assert!(matches!(
+            verify_recovery_supersede(&seized, &novel, &dir, &kg, &sm, &ss),
+            Err(LiveQuorumError::RecoveryNotKnownGood { .. })
+        ));
+    }
+
+    #[test]
+    fn recovery_without_steward_quorum_is_not_authorized() {
+        let (seized, recovery, dir, kg, sm, _stewards) = recovery_fixture();
+        // no steward signatures → not authorized (but structurally a valid target).
+        let v = verify_recovery_supersede(&seized, &recovery, &dir, &kg, &sm, &[]).unwrap();
+        assert!(!v.authorized, "the steward quorum is required to roll back");
     }
 }

--- a/src/ciris-verify-core/src/accord_live_quorum.rs
+++ b/src/ciris-verify-core/src/accord_live_quorum.rs
@@ -293,6 +293,39 @@ pub enum LiveQuorumError {
         /// The action the proposal actually carries.
         got: &'static str,
     },
+    /// The proposed roster-change envelope failed a structural invariant
+    /// (distinct/strict-majority/entrenchment/anti-replay anchor) — wraps the
+    /// `accord_genesis` validator's reason (C3).
+    Structure(String),
+    /// `proposal.payload_sha256` does not equal the digest of the proposed new
+    /// family envelope (the proposal doesn't bind *what* is being installed).
+    PayloadMismatch {
+        /// Digest of the proposed new envelope.
+        expected: String,
+        /// `payload_sha256` the proposal carried.
+        got: String,
+    },
+    /// `proposal.prior_family_digest` does not equal the digest of the standing
+    /// family envelope (the C3 anti-replay anchor is not bound to this prior state).
+    AnchorMismatch {
+        /// Digest of the standing (prior) envelope.
+        expected: String,
+        /// `prior_family_digest` the proposal carried.
+        got: String,
+    },
+    /// The proposed roster has fewer than 2 members — a `1/1` rebuild is a single
+    /// point of compromise and is rejected (H5, `N_min > 1`).
+    RosterTooSmall {
+        /// The proposed roster size.
+        size: usize,
+    },
+    /// A standing member was removed by the change but did NOT prove life (∉ `L`)
+    /// — removal-under-cover-of-absence is forbidden (H5): a censored member can't
+    /// be dropped by the live quorum.
+    RemovedAbsentMember {
+        /// The `member_id` that would be removed without consenting/participating.
+        member_id: String,
+    },
     /// The hybrid signature did not verify over the recomputed canonical bytes.
     Signature(String),
 }
@@ -329,6 +362,22 @@ impl std::fmt::Display for LiveQuorumError {
             Self::WrongAction { expected, got } => {
                 write!(f, "wrong proposal action: expected {expected}, got {got}")
             },
+            Self::Structure(e) => write!(f, "roster-change structure invalid: {e}"),
+            Self::PayloadMismatch { expected, got } => write!(
+                f,
+                "proposal payload_sha256 {got} != proposed new-envelope digest {expected}"
+            ),
+            Self::AnchorMismatch { expected, got } => write!(
+                f,
+                "proposal prior_family_digest {got} != standing envelope digest {expected} (C3)"
+            ),
+            Self::RosterTooSmall { size } => {
+                write!(f, "proposed roster has {size} members; N_min is 2 (H5)")
+            },
+            Self::RemovedAbsentMember { member_id } => write!(
+                f,
+                "standing member {member_id} removed without proving life ∉ L (H5)"
+            ),
             Self::Signature(e) => write!(f, "participation signature invalid: {e}"),
         }
     }
@@ -450,6 +499,149 @@ pub fn verify_fire_by_live_quorum(
     Ok(FireVerdict {
         fired: tally.yes >= 1,
         tally,
+    })
+}
+
+/// The `L_floor` below which a roster change additionally requires the steward
+/// backstop (CC §4.2.6 / FSD-004 Q4). At `|L| < 3` a lone or pair of (possibly
+/// coerced) survivors must not be able to rebuild the roster unaided.
+pub const L_FLOOR: usize = 3;
+
+/// The verdict of a live-quorum roster change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RosterChangeVerdict {
+    /// Whether the change is authorized (strict-majority-of-`L` yes votes, plus
+    /// the steward backstop when it was required).
+    pub authorized: bool,
+    /// The frozen tally over `L`.
+    pub tally: LiveQuorumTally,
+    /// Whether `|L| < L_FLOOR` forced the steward 2-of-3 backstop (H6).
+    pub used_steward_backstop: bool,
+}
+
+/// Verify a live-quorum **roster change** (grow / shrink / swap) — the
+/// decimation-recovery rebuild (FSD-004 / CC §4.2.6).
+///
+/// Authorization is the live set `L`'s strict majority, but **every other
+/// invariant is anchored to the standing roster, never `L`** (C3). Checks:
+/// 1. the proposal is a [`AccordAction::RosterChange`];
+/// 2. **structure** ([`crate::accord_genesis::validate_membership_change_structure`]):
+///    distinct + strict-majority new roster, distinct pubkeys, entrenchment +
+///    `family_key_id` preserved, and `supersedes.prior_member_key_ids ==` the
+///    **standing** roster (the C3 anti-replay anchor);
+/// 3. the proposal binds the change — `payload_sha256 ==` the new envelope digest
+///    and `prior_family_digest ==` the standing envelope digest (C3);
+/// 4. the tally over `L` (signers resolved only in the standing roster, M3);
+/// 5. **`N_min`** — the new roster has ≥ 2 members (no `1/1` rebuild, H5);
+/// 6. **removal-continuity** — any standing member *removed* by the change MUST
+///    have proved life (`∈ L`); a censored/absent member can't be dropped (H5);
+/// 7. **authorization** — `yes ≥ strict_majority(|L|)`, AND when `|L| < L_FLOOR`
+///    the **steward 2-of-3 backstop** over the proposal (a key-independent trust
+///    domain, H6) computed on the **server-recomputed** `|L|`.
+///
+/// Steps 1-6 fail-closed with an error (the change is malformed/illegal); step 7
+/// is reported as [`RosterChangeVerdict::authorized`] (a valid tally that did or
+/// didn't reach the bar).
+///
+/// # Errors
+/// [`LiveQuorumError`] for a wrong action, a structural/binding violation, an
+/// undersized roster, or removal of an absent member.
+#[allow(clippy::too_many_arguments)]
+pub fn verify_membership_change_by_live_quorum(
+    proposal: &AccordProposal,
+    participations: &[AccordParticipation],
+    prior_envelope: &serde_json::Value,
+    new_envelope: &serde_json::Value,
+    standing_roster: &[ThresholdMember],
+    steward_members: &[ThresholdMember],
+    steward_signatures: &[ThresholdSignature],
+) -> Result<RosterChangeVerdict, LiveQuorumError> {
+    // 1. Action.
+    if proposal.action != AccordAction::RosterChange {
+        return Err(LiveQuorumError::WrongAction {
+            expected: "roster_change",
+            got: proposal.action.as_str(),
+        });
+    }
+
+    // 2. Structure (C3 anchor on the standing roster, entrenchment, distinct, etc.)
+    crate::accord_genesis::validate_membership_change_structure(
+        prior_envelope,
+        new_envelope,
+        standing_roster,
+    )
+    .map_err(|e| LiveQuorumError::Structure(e.to_string()))?;
+
+    // 3. The proposal binds the proposed change + the standing prior state (C3).
+    let envelope_digest = |env: &serde_json::Value| -> Result<String, LiveQuorumError> {
+        let bytes = crate::accord_genesis::accord_family_signing_bytes(env)
+            .map_err(|e| LiveQuorumError::Structure(e.to_string()))?;
+        let mut h = Sha256::new();
+        h.update(&bytes);
+        Ok(hex::encode(h.finalize()))
+    };
+    let new_digest = envelope_digest(new_envelope)?;
+    if proposal.payload_sha256 != new_digest {
+        return Err(LiveQuorumError::PayloadMismatch {
+            expected: new_digest,
+            got: proposal.payload_sha256.clone(),
+        });
+    }
+    let prior_digest = envelope_digest(prior_envelope)?;
+    if proposal.prior_family_digest != prior_digest {
+        return Err(LiveQuorumError::AnchorMismatch {
+            expected: prior_digest,
+            got: proposal.prior_family_digest.clone(),
+        });
+    }
+
+    // 4. Tally over L (anchored to the standing roster, M3/C3).
+    let tally = tally_live_quorum(proposal, participations, standing_roster)?;
+
+    // 5. N_min (H5): no 1/1 rebuild.
+    let new_ids = crate::accord_genesis::envelope_member_key_ids(new_envelope)
+        .map_err(|e| LiveQuorumError::Structure(e.to_string()))?;
+    if new_ids.len() < 2 {
+        return Err(LiveQuorumError::RosterTooSmall {
+            size: new_ids.len(),
+        });
+    }
+
+    // 6. Removal-continuity (H5): a removed standing member must have proved life.
+    let prior_ids = crate::accord_genesis::envelope_member_key_ids(prior_envelope)
+        .map_err(|e| LiveQuorumError::Structure(e.to_string()))?;
+    for removed in prior_ids.iter().filter(|id| !new_ids.contains(id)) {
+        if !tally.live_set.iter().any(|id| id == removed) {
+            return Err(LiveQuorumError::RemovedAbsentMember {
+                member_id: removed.clone(),
+            });
+        }
+    }
+
+    // 7. Authorization: strict-majority-of-L + the L_floor steward backstop (H6).
+    let majority_met = tally.yes >= crate::accord_genesis::strict_majority(tally.live_count());
+    let used_steward_backstop = tally.live_count() < L_FLOOR;
+    let steward_ok = if used_steward_backstop {
+        // 2-of-3 (strict majority) of an INDEPENDENT steward set, over the proposal
+        // bytes (which transitively bind the new roster via payload_sha256). The
+        // |L| trigger is the SERVER-recomputed tally, never a claimed value.
+        let steward_threshold =
+            crate::accord_genesis::strict_majority(steward_members.len().max(1));
+        verify_threshold_signatures(
+            &proposal.canonical_bytes(),
+            steward_members,
+            steward_signatures,
+            steward_threshold,
+        )
+        .is_ok()
+    } else {
+        true
+    };
+
+    Ok(RosterChangeVerdict {
+        authorized: majority_met && steward_ok,
+        tally,
+        used_steward_backstop,
     })
 }
 
@@ -758,6 +950,239 @@ mod tests {
                 expected: "fire",
                 ..
             })
+        ));
+    }
+
+    // --- roster-change (step 3) ---------------------------------------------
+
+    use crate::accord_genesis::{accord_family_signing_bytes, build_membership_change};
+    use crate::threshold::Role;
+    use serde_json::{json, Value};
+
+    /// A standing (prior) accord family envelope over `ids`, entrenched.
+    fn family_envelope(ids: &[&str]) -> Value {
+        let members: Vec<Value> = ids
+            .iter()
+            .map(|k| json!({ "key_id": k, "role": "founder" }))
+            .collect();
+        json!({
+            "family_key_id": "humanity-accord",
+            "family_name": "HUMANITY_ACCORD",
+            "members": members,
+            "consensus_protocol": format!("quorum:{}/{}", crate::accord_genesis::strict_majority(ids.len()), ids.len()),
+            "consensus_protocol_entrenched": true,
+        })
+    }
+
+    fn env_digest(env: &Value) -> String {
+        let bytes = accord_family_signing_bytes(env).unwrap();
+        let mut h = Sha256::new();
+        h.update(&bytes);
+        hex::encode(h.finalize())
+    }
+
+    fn roster_proposal(prior: &Value, new: &Value) -> AccordProposal {
+        AccordProposal {
+            family_key_id: "humanity-accord".to_string(),
+            action: AccordAction::RosterChange,
+            nonce: "roster-nonce-XXXXXXXXXXXXXXXXXXXXXXXX".to_string(),
+            window_until: "2026-06-29T00:00:00.000Z".to_string(),
+            prior_family_digest: env_digest(prior),
+            payload_sha256: env_digest(new),
+        }
+    }
+
+    /// Holders A1,B1,C1 (standing) + D1 (candidate) + the directory over all four.
+    fn roster_fixture() -> (Vec<Holder>, Vec<ThresholdMember>) {
+        let hs: Vec<Holder> = ["A1", "B1", "C1", "D1"]
+            .iter()
+            .map(|id| Holder::new(id))
+            .collect();
+        let dir: Vec<ThresholdMember> = hs.iter().map(Holder::member).collect();
+        (hs, dir)
+    }
+
+    #[test]
+    fn roster_grow_authorized_by_live_majority() {
+        let (hs, dir) = roster_fixture();
+        let prior = family_envelope(&["A1", "B1", "C1"]);
+        // grow A1,B1,C1 → A1,B1,C1,D1 (quorum 3/4), entrenched preserved.
+        let new = build_membership_change(
+            &prior,
+            &["A1", "B1", "C1", "D1"].map(String::from),
+            Role::Founder,
+            true,
+            None,
+        );
+        let prop = roster_proposal(&prior, &new);
+        // A1,B1,C1 prove life + vote yes → |L|=3, strict-majority(3)=2, met.
+        let parts: Vec<_> = hs[..3]
+            .iter()
+            .map(|h| participate(h, &prop, Vote::Yes))
+            .collect();
+        let v =
+            verify_membership_change_by_live_quorum(&prop, &parts, &prior, &new, &dir, &[], &[])
+                .unwrap();
+        assert!(v.authorized);
+        assert!(!v.used_steward_backstop, "|L|=3 ≥ L_FLOOR");
+        assert_eq!(v.tally.live_count(), 3);
+    }
+
+    #[test]
+    fn roster_change_below_majority_is_not_authorized() {
+        let (hs, dir) = roster_fixture();
+        let prior = family_envelope(&["A1", "B1", "C1"]);
+        let new = build_membership_change(
+            &prior,
+            &["A1", "B1", "C1", "D1"].map(String::from),
+            Role::Founder,
+            true,
+            None,
+        );
+        let prop = roster_proposal(&prior, &new);
+        // 3 live, only 1 yes (2 no) → strict-majority(3)=2 not met.
+        let parts = vec![
+            participate(&hs[0], &prop, Vote::Yes),
+            participate(&hs[1], &prop, Vote::No),
+            participate(&hs[2], &prop, Vote::No),
+        ];
+        let v =
+            verify_membership_change_by_live_quorum(&prop, &parts, &prior, &new, &dir, &[], &[])
+                .unwrap();
+        assert!(!v.authorized, "1 of 3 yes does not reach strict majority");
+    }
+
+    #[test]
+    fn shrink_to_one_member_is_rejected_n_min() {
+        // H5: a 1/1 rebuild is a single point of compromise.
+        let (hs, dir) = roster_fixture();
+        let prior = family_envelope(&["A1", "B1", "C1"]);
+        // attempt A1,B1,C1 → A1 only (would be quorum:1/1). Removed B1,C1 ARE in L
+        // (so it's not the removal-continuity error — it's the size floor).
+        let new = build_membership_change(&prior, &["A1".to_string()], Role::Founder, true, None);
+        let prop = roster_proposal(&prior, &new);
+        let parts: Vec<_> = hs[..3]
+            .iter()
+            .map(|h| participate(h, &prop, Vote::Yes))
+            .collect();
+        assert!(matches!(
+            verify_membership_change_by_live_quorum(&prop, &parts, &prior, &new, &dir, &[], &[]),
+            Err(LiveQuorumError::RosterTooSmall { size: 1 })
+        ));
+    }
+
+    #[test]
+    fn removing_a_censored_member_is_rejected() {
+        // H5 removal-continuity: C1 is censored (∉ L) and the change drops C1.
+        let (hs, dir) = roster_fixture();
+        let prior = family_envelope(&["A1", "B1", "C1"]);
+        // shrink A1,B1,C1 → A1,B1 (quorum 2/2 — valid 2·2>2). C1 removed.
+        let new = build_membership_change(
+            &prior,
+            &["A1", "B1"].map(String::from),
+            Role::Founder,
+            true,
+            None,
+        );
+        let prop = roster_proposal(&prior, &new);
+        // only A1,B1 prove life — C1 is absent/censored.
+        let parts = vec![
+            participate(&hs[0], &prop, Vote::Yes),
+            participate(&hs[1], &prop, Vote::Yes),
+        ];
+        // |L|=2 < L_FLOOR triggers the steward backstop; supply valid stewards so
+        // the test isolates the removal-continuity check (which fires first).
+        let stewards: Vec<Holder> = ["S1", "S2", "S3"]
+            .iter()
+            .map(|id| Holder::new(id))
+            .collect();
+        let sm: Vec<ThresholdMember> = stewards.iter().map(Holder::member).collect();
+        let ss: Vec<ThresholdSignature> = stewards[..2]
+            .iter()
+            .map(|s| s.sign(&prop.canonical_bytes()))
+            .collect();
+        assert!(matches!(
+            verify_membership_change_by_live_quorum(&prop, &parts, &prior, &new, &dir, &sm, &ss),
+            Err(LiveQuorumError::RemovedAbsentMember { .. })
+        ));
+    }
+
+    #[test]
+    fn steward_backstop_required_below_l_floor() {
+        // H6: |L| < 3 requires the 2-of-3 steward co-sign; without it, not authorized.
+        let (hs, dir) = roster_fixture();
+        let prior = family_envelope(&["A1", "B1", "C1"]);
+        // grow A1,B1,C1 → A1,B1,C1,D1; only A1,B1 prove life → |L|=2 < L_FLOOR.
+        let new = build_membership_change(
+            &prior,
+            &["A1", "B1", "C1", "D1"].map(String::from),
+            Role::Founder,
+            true,
+            None,
+        );
+        let prop = roster_proposal(&prior, &new);
+        let parts = vec![
+            participate(&hs[0], &prop, Vote::Yes),
+            participate(&hs[1], &prop, Vote::Yes),
+        ];
+        let stewards: Vec<Holder> = ["S1", "S2", "S3"]
+            .iter()
+            .map(|id| Holder::new(id))
+            .collect();
+        let sm: Vec<ThresholdMember> = stewards.iter().map(Holder::member).collect();
+
+        // Without steward sigs → backstop unmet → not authorized.
+        let v_no =
+            verify_membership_change_by_live_quorum(&prop, &parts, &prior, &new, &dir, &sm, &[])
+                .unwrap();
+        assert!(v_no.used_steward_backstop);
+        assert!(
+            !v_no.authorized,
+            "|L|<3 with no steward co-sign is not authorized"
+        );
+
+        // With 2-of-3 valid steward sigs → authorized.
+        let ss: Vec<ThresholdSignature> = stewards[..2]
+            .iter()
+            .map(|s| s.sign(&prop.canonical_bytes()))
+            .collect();
+        let v_yes =
+            verify_membership_change_by_live_quorum(&prop, &parts, &prior, &new, &dir, &sm, &ss)
+                .unwrap();
+        assert!(v_yes.used_steward_backstop);
+        assert!(v_yes.authorized, "|L|<3 + 2-of-3 stewards authorizes");
+    }
+
+    #[test]
+    fn roster_anchor_and_payload_must_bind() {
+        let (hs, dir) = roster_fixture();
+        let prior = family_envelope(&["A1", "B1", "C1"]);
+        let new = build_membership_change(
+            &prior,
+            &["A1", "B1", "C1", "D1"].map(String::from),
+            Role::Founder,
+            true,
+            None,
+        );
+        // Wrong prior_family_digest (C3 anchor) → AnchorMismatch.
+        let mut bad_anchor = roster_proposal(&prior, &new);
+        bad_anchor.prior_family_digest = "f".repeat(64);
+        // participations must bind THIS (bad) proposal to reach the anchor check
+        let parts_bad: Vec<_> = hs[..3]
+            .iter()
+            .map(|h| participate(h, &bad_anchor, Vote::Yes))
+            .collect();
+        assert!(matches!(
+            verify_membership_change_by_live_quorum(
+                &bad_anchor,
+                &parts_bad,
+                &prior,
+                &new,
+                &dir,
+                &[],
+                &[]
+            ),
+            Err(LiveQuorumError::AnchorMismatch { .. })
         ));
     }
 }

--- a/src/ciris-verify-core/src/accord_live_quorum.rs
+++ b/src/ciris-verify-core/src/accord_live_quorum.rs
@@ -1,0 +1,518 @@
+//! HUMANITY_ACCORD live-quorum objects — Phase 1, step 1 (FSD-004 / CC §4.2.6).
+//!
+//! The wire objects the live-quorum decimation-recovery rides on:
+//! `AccordProposal` (the action + server-issued nonce + window) and
+//! `AccordParticipation` (a holder's **proof-of-life bundled with a vote** in
+//! ONE signed object — entering the live set `L` and voting are the same act).
+//! The tally / membership-change / fire surfaces are step 2.
+//!
+//! This module exists to satisfy the **CRITICAL** obligations the adversarial
+//! review (`FSD/FSD-004_ADVERSARIAL_REVIEW.md`) found in the design's soft
+//! underbelly — the participation preimage — *before* any tally code is written:
+//!
+//! - **C1 (vote-flip / cross-proposal replay):** `AccordParticipation` has an
+//!   exact, domain-separated `canonical_bytes`
+//!   that binds — INSIDE the signed preimage — the **vote**, the **full proposal
+//!   digest** (not a bare nonce), the **member seat**, the **family**, and the
+//!   **window**. A relay/server cannot flip a recorded vote or replay a
+//!   participation into a different proposal without breaking the signature.
+//! - **C3 (anti-replay anchor):** the proposal binds `prior_family_digest` — the
+//!   digest of the **standing** family envelope — so a participation is bound to a
+//!   decision over a specific standing roster, never the manipulable live set.
+//!   (The tally in step 2 keeps the anti-replay anchor on the standing roster.)
+//! - **M3 (directory-only resolution):** a participation's signature is verified
+//!   against the holder's **pinned** `ThresholdMember` key, and its `member_id`
+//!   self-attests its seat in the preimage.
+//! - **M5 (`family_key_id` binding):** bound in the preimage, so a participation
+//!   is non-transferable across families by construction.
+//!
+//! Both preimages use the same line-format `domain_prefix ‖ k=v\n…` discipline as
+//! `crate::humanity_accord::Invocation`, with **distinct domain prefixes** so a
+//! participation signature can never verify as an invoke / lifecycle / proposal
+//! signature (the CC §9.2 "wire-isolated AND scope-isolated" property).
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::threshold::{verify_threshold_signatures, ThresholdMember, ThresholdSignature};
+
+/// Domain prefix for `AccordProposal` canonical bytes (trailing `\n` included).
+pub const PROPOSAL_DOMAIN_PREFIX: &str = "ciris.accord_proposal.v1\n";
+/// Domain prefix for `AccordParticipation` canonical bytes (trailing `\n`).
+pub const PARTICIPATION_DOMAIN_PREFIX: &str = "ciris.accord_participation.v1\n";
+
+/// The action an `AccordProposal` opens for a live-quorum decision.
+///
+/// `DECIMATION` is a quorum-computation rule over the existing `CONSTITUTIONAL`
+/// kind, not a new invocation verb (FSD-004 §11) — so the *action* is just which
+/// of the two decision shapes this proposal seeks. The closed set keeps an
+/// unknown action fail-closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccordAction {
+    /// A live-quorum `CONSTITUTIONAL` fire (tallied at the floor of 1 in step 2).
+    Fire,
+    /// A roster grow / shrink / swap (tallied at strict-majority-of-`L` + the
+    /// `L_floor` steward backstop in step 2), carried as a family `supersedes`.
+    RosterChange,
+}
+
+impl AccordAction {
+    /// Canonical wire token.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Fire => "fire",
+            Self::RosterChange => "roster_change",
+        }
+    }
+}
+
+/// A holder's vote, carried INSIDE the signed `AccordParticipation` preimage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Vote {
+    /// In favour of the proposed action.
+    Yes,
+    /// Against the proposed action.
+    No,
+    /// Present (counts toward `L`) but expresses no preference.
+    Abstain,
+}
+
+impl Vote {
+    /// Canonical wire token — part of the signed bytes (C1).
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Yes => "yes",
+            Self::No => "no",
+            Self::Abstain => "abstain",
+        }
+    }
+}
+
+/// An accord live-quorum proposal: the action, the **server-issued** freshness
+/// nonce, the window upper bound, and the standing-roster anti-replay anchor.
+///
+/// The proposal's `digest` is what every
+/// `AccordParticipation` binds to — so a participation is non-transferable
+/// between proposals even if a nonce ever collided (C1/C3).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccordProposal {
+    /// The accord family this decision is for (e.g. `humanity-accord`).
+    pub family_key_id: String,
+    /// What is being decided.
+    pub action: AccordAction,
+    /// Server-issued freshness nonce, `base64url(rand_32)`. Verify checks form;
+    /// the authoritative server owns issuance + the issued-nonce set (M4).
+    pub nonce: String,
+    /// §0.5 canonical RFC 3339 — the window upper bound `W`. The authoritative
+    /// `L` membership is server-observed arrival within `W`, NOT a holder's
+    /// self-asserted `signed_at` (C2); this field pins `W` into the signed bytes.
+    pub window_until: String,
+    /// Lowercase-hex SHA-256 of the **standing** family envelope this decision
+    /// supersedes — the anti-replay anchor (C3). Bound here so two decisions over
+    /// the same prior digest are detectable as a fork (the step-2 equivocation
+    /// gate, H3).
+    pub prior_family_digest: String,
+    /// Lowercase-hex SHA-256 of the action payload (the proposed `supersedes` for
+    /// a roster change, or the halt payload for a fire). Binds *what* is proposed.
+    pub payload_sha256: String,
+}
+
+impl AccordProposal {
+    /// §4.2.6 canonical bytes — the line-format preimage, domain-separated.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        format!(
+            "{PROPOSAL_DOMAIN_PREFIX}family_key_id={fk}\naction={action}\nnonce={nonce}\nwindow_until={wu}\nprior_family_digest={pfd}\npayload_sha256={ph}",
+            fk = self.family_key_id,
+            action = self.action.as_str(),
+            nonce = self.nonce,
+            wu = self.window_until,
+            pfd = self.prior_family_digest,
+            ph = self.payload_sha256,
+        )
+        .into_bytes()
+    }
+
+    /// Lowercase-hex SHA-256 of the canonical bytes — the `proposal_digest` every
+    /// participation binds to (C1/C3).
+    #[must_use]
+    pub fn digest(&self) -> String {
+        let mut h = Sha256::new();
+        h.update(self.canonical_bytes());
+        hex::encode(h.finalize())
+    }
+}
+
+/// A holder's proof-of-life **bundled with** a vote — entering `L` and voting are
+/// one signed act (FSD-004 §4.2 / §6). The signature is a hybrid (Ed25519 +
+/// ML-DSA-65) `ThresholdSignature` over `canonical_bytes`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccordParticipation {
+    /// MUST equal the proposal's `family_key_id` (M5; checked in `verify`).
+    pub family_key_id: String,
+    /// Lowercase-hex digest of the ONE proposal this participates in (C1/C3).
+    pub proposal_digest: String,
+    /// The holder's roster seat — self-attested in the preimage (M3).
+    pub member_id: String,
+    /// The vote, INSIDE the signed bytes (C1) — un-flippable post-signature.
+    pub vote: Vote,
+    /// The proposal's `window_until`, bound into the signed bytes (C2). The
+    /// authoritative `L`-gate is server arrival time; this is the signed copy.
+    pub window_until: String,
+    /// §0.5 RFC 3339. **Advisory display only** — MUST NOT gate `L` (C2). Bound
+    /// in the preimage for completeness/audit, never trusted as the window clock.
+    pub signed_at: String,
+    /// The holder's hybrid signature over the canonical bytes.
+    pub signature: ThresholdSignature,
+}
+
+impl AccordParticipation {
+    /// CC §4.2.6 canonical bytes — domain-separated, with the **vote**, **proposal
+    /// digest**, **member seat**, **family**, and **window** all inside the signed
+    /// preimage (C1/C2/M3/M5). `proof_of_life=true` is implicit in a valid
+    /// participation existing; it is written explicitly so the preimage reads as
+    /// the proof-of-life-plus-vote bundle it is.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        format!(
+            "{PARTICIPATION_DOMAIN_PREFIX}family_key_id={fk}\nproposal_digest={pd}\nmember_id={mid}\nproof_of_life=true\nvote={vote}\nwindow_until={wu}\nsigned_at={sa}",
+            fk = self.family_key_id,
+            pd = self.proposal_digest,
+            mid = self.member_id,
+            vote = self.vote.as_str(),
+            wu = self.window_until,
+            sa = self.signed_at,
+        )
+        .into_bytes()
+    }
+
+    /// Verify this participation against the proposal it claims and the holder's
+    /// **pinned** directory key — fail-closed on every mismatch.
+    ///
+    /// Checks, in order: the participation binds THIS proposal's digest (C1/C3),
+    /// the family matches (M5), the `member_id` is consistent across the object +
+    /// the signature + the pinned member (M3), and the holder's **hybrid**
+    /// signature verifies over the recomputed canonical bytes (RequireHybrid at
+    /// the federation tier). A participation that passes is a valid, vote-bound
+    /// member of `L` for `proposal`.
+    ///
+    /// # Errors
+    /// `LiveQuorumError` describing the first failed check.
+    pub fn verify(
+        &self,
+        member: &ThresholdMember,
+        proposal: &AccordProposal,
+    ) -> Result<(), LiveQuorumError> {
+        // C1/C3: bound to exactly this proposal — a participation for a different
+        // proposal (or a bare-nonce replay) does not carry this digest.
+        let expected = proposal.digest();
+        if self.proposal_digest != expected {
+            return Err(LiveQuorumError::ProposalMismatch {
+                expected,
+                got: self.proposal_digest.clone(),
+            });
+        }
+        // M5: same family.
+        if self.family_key_id != proposal.family_key_id {
+            return Err(LiveQuorumError::FamilyMismatch {
+                proposal: proposal.family_key_id.clone(),
+                participation: self.family_key_id.clone(),
+            });
+        }
+        // M3: the seat self-attested in the object, in the signature, and in the
+        // pinned directory member must all agree.
+        if self.member_id != self.signature.member_id || self.member_id != member.member_id {
+            return Err(LiveQuorumError::MemberMismatch {
+                participation: self.member_id.clone(),
+                signature: self.signature.member_id.clone(),
+                pinned: member.member_id.clone(),
+            });
+        }
+        // The hybrid signature must verify over the recomputed canonical bytes,
+        // against the pinned key, at the federation tier (RequireHybrid default).
+        let canonical = self.canonical_bytes();
+        verify_threshold_signatures(
+            &canonical,
+            std::slice::from_ref(member),
+            std::slice::from_ref(&self.signature),
+            1,
+        )
+        .map_err(|e| LiveQuorumError::Signature(format!("{e:?}")))?;
+        Ok(())
+    }
+}
+
+/// Why a live-quorum object failed verification — fail-closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LiveQuorumError {
+    /// The participation's `proposal_digest` does not match the proposal it was
+    /// verified against (C1/C3 — cross-proposal replay / vote for a different
+    /// proposal).
+    ProposalMismatch {
+        /// The digest of the proposal being verified against.
+        expected: String,
+        /// The digest the participation carried.
+        got: String,
+    },
+    /// `family_key_id` mismatch between participation and proposal (M5).
+    FamilyMismatch {
+        /// The proposal's family.
+        proposal: String,
+        /// The participation's family.
+        participation: String,
+    },
+    /// The seat is inconsistent across the object / signature / pinned member (M3).
+    MemberMismatch {
+        /// `member_id` on the participation object.
+        participation: String,
+        /// `member_id` on the signature.
+        signature: String,
+        /// `member_id` of the pinned directory member.
+        pinned: String,
+    },
+    /// The hybrid signature did not verify over the recomputed canonical bytes.
+    Signature(String),
+}
+
+impl std::fmt::Display for LiveQuorumError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProposalMismatch { expected, got } => write!(
+                f,
+                "participation binds proposal {got} but was verified against {expected} (C1/C3)"
+            ),
+            Self::FamilyMismatch {
+                proposal,
+                participation,
+            } => write!(
+                f,
+                "family mismatch: proposal {proposal} vs participation {participation} (M5)"
+            ),
+            Self::MemberMismatch {
+                participation,
+                signature,
+                pinned,
+            } => write!(
+                f,
+                "member_id mismatch: object {participation} / sig {signature} / pinned {pinned} (M3)"
+            ),
+            Self::Signature(e) => write!(f, "participation signature invalid: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for LiveQuorumError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use ciris_crypto::{ClassicalSigner, Ed25519Signer, MlDsa65Signer, PqcSigner};
+
+    const B64: base64::engine::general_purpose::GeneralPurpose =
+        base64::engine::general_purpose::STANDARD;
+
+    /// A holder with hybrid keys (mirrors the `threshold` test `Party`).
+    struct Holder {
+        member_id: String,
+        ed: Ed25519Signer,
+        mldsa: MlDsa65Signer,
+    }
+
+    impl Holder {
+        fn new(id: &str) -> Self {
+            Self {
+                member_id: id.to_string(),
+                ed: Ed25519Signer::random().unwrap(),
+                mldsa: MlDsa65Signer::new().unwrap(),
+            }
+        }
+        fn member(&self) -> ThresholdMember {
+            ThresholdMember {
+                member_id: self.member_id.clone(),
+                ed25519_public_key_base64: B64.encode(self.ed.public_key().unwrap()),
+                mldsa65_public_key_base64: Some(B64.encode(self.mldsa.public_key().unwrap())),
+                role: None,
+            }
+        }
+        fn sign(&self, bytes: &[u8]) -> ThresholdSignature {
+            let ed_sig = self.ed.sign(bytes).unwrap();
+            let mut bound = bytes.to_vec();
+            bound.extend_from_slice(&ed_sig);
+            ThresholdSignature {
+                member_id: self.member_id.clone(),
+                ed25519_signature_base64: B64.encode(&ed_sig),
+                mldsa65_signature_base64: Some(B64.encode(self.mldsa.sign(&bound).unwrap())),
+            }
+        }
+    }
+
+    fn sample_proposal() -> AccordProposal {
+        AccordProposal {
+            family_key_id: "humanity-accord".to_string(),
+            action: AccordAction::RosterChange,
+            nonce: "AAAAbase64url-nonce-XXXXXXXXXXXXXXXXXXXX".to_string(),
+            window_until: "2026-06-29T00:00:00.000Z".to_string(),
+            prior_family_digest: "a".repeat(64),
+            payload_sha256: "b".repeat(64),
+        }
+    }
+
+    /// Build a holder's valid, signed participation in `proposal`.
+    fn participate(h: &Holder, proposal: &AccordProposal, vote: Vote) -> AccordParticipation {
+        let mut p = AccordParticipation {
+            family_key_id: proposal.family_key_id.clone(),
+            proposal_digest: proposal.digest(),
+            member_id: h.member_id.clone(),
+            vote,
+            window_until: proposal.window_until.clone(),
+            signed_at: "2026-06-26T12:00:00.000Z".to_string(),
+            // placeholder; replaced below once we can sign the canonical bytes.
+            signature: ThresholdSignature {
+                member_id: h.member_id.clone(),
+                ed25519_signature_base64: String::new(),
+                mldsa65_signature_base64: None,
+            },
+        };
+        p.signature = h.sign(&p.canonical_bytes());
+        p
+    }
+
+    #[test]
+    fn proposal_digest_is_stable_and_field_sensitive() {
+        let p = sample_proposal();
+        assert_eq!(p.digest(), p.clone().digest(), "deterministic");
+        let mut p2 = p.clone();
+        p2.nonce = "different-nonce".to_string();
+        assert_ne!(p.digest(), p2.digest(), "nonce change → different digest");
+        let mut p3 = p.clone();
+        p3.action = AccordAction::Fire;
+        assert_ne!(p.digest(), p3.digest(), "action change → different digest");
+        let mut p4 = p.clone();
+        p4.prior_family_digest = "c".repeat(64);
+        assert_ne!(p.digest(), p4.digest(), "anchor change → different digest");
+    }
+
+    #[test]
+    fn participation_preimage_binds_the_vote() {
+        // C1: changing the vote MUST change the signed bytes.
+        let prop = sample_proposal();
+        let base = AccordParticipation {
+            family_key_id: prop.family_key_id.clone(),
+            proposal_digest: prop.digest(),
+            member_id: "A1".to_string(),
+            vote: Vote::Yes,
+            window_until: prop.window_until.clone(),
+            signed_at: "2026-06-26T12:00:00.000Z".to_string(),
+            signature: ThresholdSignature {
+                member_id: "A1".to_string(),
+                ed25519_signature_base64: String::new(),
+                mldsa65_signature_base64: None,
+            },
+        };
+        let mut no = base.clone();
+        no.vote = Vote::No;
+        assert_ne!(base.canonical_bytes(), no.canonical_bytes());
+        // and the vote is actually present in the bytes
+        let s = String::from_utf8(base.canonical_bytes()).unwrap();
+        assert!(s.contains("\nvote=yes\n"));
+        assert!(s.starts_with("ciris.accord_participation.v1\n"));
+    }
+
+    #[test]
+    fn participation_scope_is_isolated_from_proposal_and_invoke() {
+        // Distinct domain prefixes ⇒ a participation signature can't verify as a
+        // proposal/invoke/lifecycle signature even with identical content.
+        let prop = sample_proposal();
+        let part = AccordParticipation {
+            family_key_id: prop.family_key_id.clone(),
+            proposal_digest: prop.digest(),
+            member_id: "A1".to_string(),
+            vote: Vote::Yes,
+            window_until: prop.window_until.clone(),
+            signed_at: "2026-06-26T12:00:00.000Z".to_string(),
+            signature: ThresholdSignature {
+                member_id: "A1".to_string(),
+                ed25519_signature_base64: String::new(),
+                mldsa65_signature_base64: None,
+            },
+        };
+        assert!(part
+            .canonical_bytes()
+            .starts_with(b"ciris.accord_participation.v1\n"));
+        assert!(prop
+            .canonical_bytes()
+            .starts_with(b"ciris.accord_proposal.v1\n"));
+        assert_ne!(part.canonical_bytes(), prop.canonical_bytes());
+    }
+
+    #[test]
+    fn valid_participation_verifies() {
+        let h = Holder::new("A1");
+        let prop = sample_proposal();
+        let part = participate(&h, &prop, Vote::Yes);
+        assert_eq!(part.verify(&h.member(), &prop), Ok(()));
+    }
+
+    #[test]
+    fn cross_proposal_replay_is_rejected() {
+        // C1/C3: a participation signed for proposal A must not verify against B.
+        let h = Holder::new("A1");
+        let prop_a = sample_proposal();
+        let mut prop_b = sample_proposal();
+        prop_b.nonce = "a-totally-different-nonce".to_string();
+        assert_ne!(prop_a.digest(), prop_b.digest());
+
+        let part_for_a = participate(&h, &prop_a, Vote::Yes);
+        assert!(matches!(
+            part_for_a.verify(&h.member(), &prop_b),
+            Err(LiveQuorumError::ProposalMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn flipped_vote_breaks_the_signature() {
+        // C1: take a valid yes-participation, flip the recorded vote to no without
+        // re-signing — the recomputed bytes no longer match the signature.
+        let h = Holder::new("A1");
+        let prop = sample_proposal();
+        let mut part = participate(&h, &prop, Vote::Yes);
+        part.vote = Vote::No; // tamper, keep the old signature
+        assert!(matches!(
+            part.verify(&h.member(), &prop),
+            Err(LiveQuorumError::Signature(_))
+        ));
+    }
+
+    #[test]
+    fn signature_from_a_different_holder_is_rejected() {
+        // M3: a participation claiming A1 but signed by B's key fails.
+        let a = Holder::new("A1");
+        let b = Holder::new("A1"); // same claimed id, different keys
+        let prop = sample_proposal();
+        let part = participate(&b, &prop, Vote::Yes);
+        // verify against A1's pinned (real) directory key → signature mismatch
+        assert!(matches!(
+            part.verify(&a.member(), &prop),
+            Err(LiveQuorumError::Signature(_))
+        ));
+    }
+
+    #[test]
+    fn classical_only_participation_is_rejected_at_federation_tier() {
+        // The accord is a federation-tier gate (RequireHybrid): a participation
+        // with no ML-DSA half does not count.
+        let h = Holder::new("A1");
+        let prop = sample_proposal();
+        let mut part = participate(&h, &prop, Vote::Yes);
+        part.signature.mldsa65_signature_base64 = None; // strip the PQC half
+        assert!(matches!(
+            part.verify(&h.member(), &prop),
+            Err(LiveQuorumError::Signature(_))
+        ));
+    }
+}

--- a/src/ciris-verify-core/src/accord_live_quorum.rs
+++ b/src/ciris-verify-core/src/accord_live_quorum.rs
@@ -645,6 +645,67 @@ pub fn verify_membership_change_by_live_quorum(
     })
 }
 
+/// The frozen, server-attested outcome of a live-quorum decision (M2).
+///
+/// Once a window closes, `L` is **final**: it carries the immutable live-set
+/// snapshot + tally for `proposal`. A later proof-of-life is only ever admissible
+/// against a *new* proposal nonce — it never re-opens a closed window
+/// (Enoch-Arden: re-enrollment is *going-forward* only, never a retroactive
+/// recompute of a decided denominator). The authoritative server emits and
+/// append-only-logs this; consumers treat the snapshot as immutable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccordDecision {
+    /// The proposal this decides (binds the action, nonce, window, the standing
+    /// `prior_family_digest`, and `payload_sha256`).
+    pub proposal: AccordProposal,
+    /// The frozen live set `L` — the `member_id`s who proved life within `W`.
+    pub live_set: Vec<String>,
+    /// `yes` / `no` / `abstain` over `L`.
+    pub yes: usize,
+    /// See [`Self::yes`].
+    pub no: usize,
+    /// See [`Self::yes`].
+    pub abstain: usize,
+    /// The verdict (fired, or roster-change authorized).
+    pub authorized: bool,
+}
+
+impl AccordDecision {
+    /// Assemble a decision from a proposal + its frozen tally + the verdict.
+    #[must_use]
+    pub fn new(proposal: AccordProposal, tally: &LiveQuorumTally, authorized: bool) -> Self {
+        Self {
+            proposal,
+            live_set: tally.live_set.clone(),
+            yes: tally.yes,
+            no: tally.no,
+            abstain: tally.abstain,
+            authorized,
+        }
+    }
+}
+
+/// Whether two decisions **equivocate** — the H3 split-brain fork.
+///
+/// Two roster-change decisions equivocate iff they supersede the **same standing
+/// roster** (same `family_key_id` + `prior_family_digest`) into **different new
+/// rosters** (`payload_sha256` differs). Under partition each may be locally
+/// "authorized" by a different live set, but installing two different rosters off
+/// one prior state is a fork: the authoritative server MUST treat a detected
+/// equivocation as a **hard fail-closed conflict**, admitting neither pending the
+/// steward reconciliation, rather than last-writer-wins.
+///
+/// (A re-proposal of the *same* outcome — identical `payload_sha256` — is not an
+/// equivocation; that's the H4 coalescing case, handled server-side.)
+#[must_use]
+pub fn decisions_equivocate(a: &AccordDecision, b: &AccordDecision) -> bool {
+    a.proposal.action == AccordAction::RosterChange
+        && b.proposal.action == AccordAction::RosterChange
+        && a.proposal.family_key_id == b.proposal.family_key_id
+        && a.proposal.prior_family_digest == b.proposal.prior_family_digest
+        && a.proposal.payload_sha256 != b.proposal.payload_sha256
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1184,5 +1245,122 @@ mod tests {
             ),
             Err(LiveQuorumError::AnchorMismatch { .. })
         ));
+    }
+
+    // --- decision + equivocation (step 4) -----------------------------------
+
+    fn decision_for(
+        prop: AccordProposal,
+        yes: usize,
+        no: usize,
+        authorized: bool,
+    ) -> AccordDecision {
+        let tally = LiveQuorumTally {
+            live_set: (0..(yes + no)).map(|i| format!("M{i}")).collect(),
+            yes,
+            no,
+            abstain: 0,
+        };
+        AccordDecision::new(prop, &tally, authorized)
+    }
+
+    #[test]
+    fn decision_freezes_the_tally() {
+        let prior = family_envelope(&["A1", "B1", "C1"]);
+        let new = build_membership_change(
+            &prior,
+            &["A1", "B1", "C1", "D1"].map(String::from),
+            Role::Founder,
+            true,
+            None,
+        );
+        let prop = roster_proposal(&prior, &new);
+        let tally = LiveQuorumTally {
+            live_set: vec!["A1".into(), "B1".into(), "C1".into()],
+            yes: 3,
+            no: 0,
+            abstain: 0,
+        };
+        let d = AccordDecision::new(prop.clone(), &tally, true);
+        assert_eq!(d.live_set, tally.live_set);
+        assert_eq!((d.yes, d.no, d.abstain), (3, 0, 0));
+        assert!(d.authorized);
+        assert_eq!(d.proposal, prop);
+    }
+
+    #[test]
+    fn two_rosters_off_the_same_prior_equivocate() {
+        // H3: two roster-changes superseding the SAME standing roster into
+        // DIFFERENT new rosters are a fork — both must be rejected.
+        let prior = family_envelope(&["A1", "B1", "C1"]);
+        let new_x = build_membership_change(
+            &prior,
+            &["A1", "B1", "C1", "D1"].map(String::from),
+            Role::Founder,
+            true,
+            None,
+        );
+        let new_y = build_membership_change(
+            &prior,
+            &["A1", "B1", "C1", "E1"].map(String::from), // different new member
+            Role::Founder,
+            true,
+            None,
+        );
+        let dx = decision_for(roster_proposal(&prior, &new_x), 3, 0, true);
+        let dy = decision_for(roster_proposal(&prior, &new_y), 3, 0, true);
+        assert!(
+            decisions_equivocate(&dx, &dy),
+            "different new rosters off one prior = equivocation"
+        );
+    }
+
+    #[test]
+    fn same_outcome_re_proposal_does_not_equivocate() {
+        // The H4 coalescing case (same outcome, different nonce) is NOT a fork.
+        let prior = family_envelope(&["A1", "B1", "C1"]);
+        let new = build_membership_change(
+            &prior,
+            &["A1", "B1", "C1", "D1"].map(String::from),
+            Role::Founder,
+            true,
+            None,
+        );
+        let mut p1 = roster_proposal(&prior, &new);
+        let mut p2 = roster_proposal(&prior, &new);
+        p1.nonce = "nonce-one-aaaaaaaaaaaaaaaaaaaaaaaa".into();
+        p2.nonce = "nonce-two-bbbbbbbbbbbbbbbbbbbbbbbb".into();
+        let d1 = decision_for(p1, 2, 1, true);
+        let d2 = decision_for(p2, 3, 0, true);
+        assert!(
+            !decisions_equivocate(&d1, &d2),
+            "same prior + same new roster (different nonce) is coalescing, not a fork"
+        );
+    }
+
+    #[test]
+    fn decisions_off_different_priors_do_not_equivocate() {
+        let prior_a = family_envelope(&["A1", "B1", "C1"]);
+        let prior_b = family_envelope(&["A1", "B1", "D1"]); // different standing roster
+        let new_a = build_membership_change(
+            &prior_a,
+            &["A1", "B1", "C1", "D1"].map(String::from),
+            Role::Founder,
+            true,
+            None,
+        );
+        let new_b = build_membership_change(
+            &prior_b,
+            &["A1", "B1", "D1", "E1"].map(String::from),
+            Role::Founder,
+            true,
+            None,
+        );
+        let da = decision_for(roster_proposal(&prior_a, &new_a), 3, 0, true);
+        let db = decision_for(roster_proposal(&prior_b, &new_b), 3, 0, true);
+        assert!(
+            !decisions_equivocate(&da, &db),
+            "different prior digests are sequential states, not a fork"
+        );
     }
 }

--- a/src/ciris-verify-core/src/accord_live_quorum.rs
+++ b/src/ciris-verify-core/src/accord_live_quorum.rs
@@ -274,6 +274,25 @@ pub enum LiveQuorumError {
         /// `member_id` of the pinned directory member.
         pinned: String,
     },
+    /// A participation names a member that is NOT in the pinned standing roster
+    /// (C3 — `L ⊆ standing roster`; only real, key-holding members count).
+    NotInStandingRoster {
+        /// The unrecognized `member_id`.
+        member_id: String,
+    },
+    /// The same member appears twice in one tally — a member counts once (M3).
+    DuplicateParticipant {
+        /// The duplicated `member_id`.
+        member_id: String,
+    },
+    /// The proposal's action is not the one this verifier handles (fire vs.
+    /// roster-change).
+    WrongAction {
+        /// The action this verifier expects.
+        expected: &'static str,
+        /// The action the proposal actually carries.
+        got: &'static str,
+    },
     /// The hybrid signature did not verify over the recomputed canonical bytes.
     Signature(String),
 }
@@ -300,12 +319,139 @@ impl std::fmt::Display for LiveQuorumError {
                 f,
                 "member_id mismatch: object {participation} / sig {signature} / pinned {pinned} (M3)"
             ),
+            Self::NotInStandingRoster { member_id } => write!(
+                f,
+                "participant {member_id} is not in the pinned standing roster (C3)"
+            ),
+            Self::DuplicateParticipant { member_id } => {
+                write!(f, "member {member_id} participated twice in one tally (M3)")
+            },
+            Self::WrongAction { expected, got } => {
+                write!(f, "wrong proposal action: expected {expected}, got {got}")
+            },
             Self::Signature(e) => write!(f, "participation signature invalid: {e}"),
         }
     }
 }
 
 impl std::error::Error for LiveQuorumError {}
+
+/// The result of tallying participations over the live set — the frozen `L` (M2)
+/// plus the vote breakdown. `live_set` is the distinct set of members who proved
+/// life, each verified against the **standing** roster (C3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveQuorumTally {
+    /// `member_id`s who proved life within the window — distinct, each a verified
+    /// standing-roster member. This is the live set `L`.
+    pub live_set: Vec<String>,
+    /// `yes` votes within `L`.
+    pub yes: usize,
+    /// `no` votes within `L`.
+    pub no: usize,
+    /// `abstain` votes within `L` (present, no preference).
+    pub abstain: usize,
+}
+
+impl LiveQuorumTally {
+    /// `|L|` — the size of the live set.
+    #[must_use]
+    pub fn live_count(&self) -> usize {
+        self.live_set.len()
+    }
+}
+
+/// Tally `participations` against `proposal` over the **standing** roster.
+///
+/// Each participation is cryptographically verified ([`AccordParticipation::verify`]
+/// — sig + proposal-digest binding + family), and its signer is resolved **only**
+/// against `standing_roster` (C3/M3: `L ⊆ standing roster`, never a bundle-embedded
+/// roster). `L` is deduped by member (a member counts once). **Fail-closed:** any
+/// participation that fails verification, names a non-standing member, or duplicates
+/// a member rejects the whole tally.
+///
+/// **Window boundary (C2):** the authoritative-server window gate — `L` membership
+/// by **server-observed arrival within `W`** — is the *caller's* responsibility.
+/// This function is the cryptographic + roster-membership core; CIRISServer filters
+/// participations by arrival time before calling it. `signed_at` is never trusted
+/// as the clock.
+///
+/// # Errors
+/// [`LiveQuorumError`] on the first failed participation.
+pub fn tally_live_quorum(
+    proposal: &AccordProposal,
+    participations: &[AccordParticipation],
+    standing_roster: &[ThresholdMember],
+) -> Result<LiveQuorumTally, LiveQuorumError> {
+    let mut live_set: Vec<String> = Vec::with_capacity(participations.len());
+    let (mut yes, mut no, mut abstain) = (0usize, 0usize, 0usize);
+    for p in participations {
+        // C3/M3: resolve the signer ONLY in the pinned standing roster.
+        let member = standing_roster
+            .iter()
+            .find(|m| m.member_id == p.member_id)
+            .ok_or_else(|| LiveQuorumError::NotInStandingRoster {
+                member_id: p.member_id.clone(),
+            })?;
+        p.verify(member, proposal)?;
+        // M3: a member counts once.
+        if live_set.iter().any(|id| id == &p.member_id) {
+            return Err(LiveQuorumError::DuplicateParticipant {
+                member_id: p.member_id.clone(),
+            });
+        }
+        live_set.push(p.member_id.clone());
+        match p.vote {
+            Vote::Yes => yes += 1,
+            Vote::No => no += 1,
+            Vote::Abstain => abstain += 1,
+        }
+    }
+    Ok(LiveQuorumTally {
+        live_set,
+        yes,
+        no,
+        abstain,
+    })
+}
+
+/// The verdict of a live-quorum FIRE.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FireVerdict {
+    /// Whether the kill-switch fired.
+    pub fired: bool,
+    /// The frozen tally the verdict was computed over.
+    pub tally: LiveQuorumTally,
+}
+
+/// Whether a live-quorum `CONSTITUTIONAL` FIRE is authorized.
+///
+/// **M1 — the fire floor is pinned to 1:** a SINGLE `yes` participation in `L`
+/// fires. Firing leans easiest because a missed fire is terminal; the floor is
+/// **never** `strict_majority(|L|)` (which would let an adversary inflate `|L|`
+/// with captured keys to raise the fire bar — a suppression lever). The
+/// `fire ≤ roster-change ≤ standing` bias gradient (CC §4.2.1.3) starts here.
+///
+/// # Errors
+/// [`LiveQuorumError::WrongAction`] if `proposal.action` isn't [`AccordAction::Fire`];
+/// any [`tally_live_quorum`] error.
+pub fn verify_fire_by_live_quorum(
+    proposal: &AccordProposal,
+    participations: &[AccordParticipation],
+    standing_roster: &[ThresholdMember],
+) -> Result<FireVerdict, LiveQuorumError> {
+    if proposal.action != AccordAction::Fire {
+        return Err(LiveQuorumError::WrongAction {
+            expected: "fire",
+            got: proposal.action.as_str(),
+        });
+    }
+    let tally = tally_live_quorum(proposal, participations, standing_roster)?;
+    // Floor of 1: any single `yes` fires.
+    Ok(FireVerdict {
+        fired: tally.yes >= 1,
+        tally,
+    })
+}
 
 #[cfg(test)]
 mod tests {
@@ -513,6 +659,105 @@ mod tests {
         assert!(matches!(
             part.verify(&h.member(), &prop),
             Err(LiveQuorumError::Signature(_))
+        ));
+    }
+
+    fn fire_proposal() -> AccordProposal {
+        let mut p = sample_proposal();
+        p.action = AccordAction::Fire;
+        p
+    }
+
+    #[test]
+    fn tally_builds_live_set_and_counts_votes() {
+        let prop = sample_proposal();
+        let hs: Vec<Holder> = ["A1", "B1", "C1"]
+            .iter()
+            .map(|id| Holder::new(id))
+            .collect();
+        let roster: Vec<ThresholdMember> = hs.iter().map(Holder::member).collect();
+        let parts = vec![
+            participate(&hs[0], &prop, Vote::Yes),
+            participate(&hs[1], &prop, Vote::Yes),
+            participate(&hs[2], &prop, Vote::No),
+        ];
+        let t = tally_live_quorum(&prop, &parts, &roster).unwrap();
+        assert_eq!(t.live_count(), 3);
+        assert_eq!((t.yes, t.no, t.abstain), (2, 1, 0));
+    }
+
+    #[test]
+    fn tally_rejects_a_non_standing_participant() {
+        // C3: only members of the pinned standing roster count.
+        let prop = sample_proposal();
+        let a = Holder::new("A1");
+        let intruder = Holder::new("X9"); // not in the roster
+        let roster = vec![a.member()];
+        let parts = vec![
+            participate(&a, &prop, Vote::Yes),
+            participate(&intruder, &prop, Vote::Yes),
+        ];
+        assert!(matches!(
+            tally_live_quorum(&prop, &parts, &roster),
+            Err(LiveQuorumError::NotInStandingRoster { .. })
+        ));
+    }
+
+    #[test]
+    fn tally_rejects_a_duplicate_participant() {
+        // M3: a member counts once.
+        let prop = sample_proposal();
+        let a = Holder::new("A1");
+        let roster = vec![a.member()];
+        let parts = vec![
+            participate(&a, &prop, Vote::Yes),
+            participate(&a, &prop, Vote::No), // same member twice
+        ];
+        assert!(matches!(
+            tally_live_quorum(&prop, &parts, &roster),
+            Err(LiveQuorumError::DuplicateParticipant { .. })
+        ));
+    }
+
+    #[test]
+    fn fire_floor_is_one_even_with_a_large_live_set() {
+        // M1: a SINGLE yes fires, regardless of |L| — the floor is never
+        // strict-majority-of-L. A big live set that mostly votes no but with one
+        // yes still fires (a missed fire is terminal; firing leans easiest).
+        let prop = fire_proposal();
+        let hs: Vec<Holder> = (0..7).map(|i| Holder::new(&format!("H{i}"))).collect();
+        let roster: Vec<ThresholdMember> = hs.iter().map(Holder::member).collect();
+        let mut parts: Vec<AccordParticipation> =
+            hs.iter().map(|h| participate(h, &prop, Vote::No)).collect();
+        // flip exactly one to yes
+        parts[3] = participate(&hs[3], &prop, Vote::Yes);
+        let v = verify_fire_by_live_quorum(&prop, &parts, &roster).unwrap();
+        assert!(v.fired, "one yes fires even with 6 no in L");
+        assert_eq!(v.tally.yes, 1);
+    }
+
+    #[test]
+    fn fire_does_not_fire_without_a_yes() {
+        let prop = fire_proposal();
+        let a = Holder::new("A1");
+        let roster = vec![a.member()];
+        let parts = vec![participate(&a, &prop, Vote::Abstain)];
+        let v = verify_fire_by_live_quorum(&prop, &parts, &roster).unwrap();
+        assert!(!v.fired, "presence without a yes does not fire");
+    }
+
+    #[test]
+    fn fire_verifier_rejects_a_roster_change_proposal() {
+        let prop = sample_proposal(); // RosterChange
+        let a = Holder::new("A1");
+        let roster = vec![a.member()];
+        let parts = vec![participate(&a, &prop, Vote::Yes)];
+        assert!(matches!(
+            verify_fire_by_live_quorum(&prop, &parts, &roster),
+            Err(LiveQuorumError::WrongAction {
+                expected: "fire",
+                ..
+            })
         ));
     }
 }

--- a/src/ciris-verify-core/src/lib.rs
+++ b/src/ciris-verify-core/src/lib.rs
@@ -58,6 +58,12 @@ pub mod accord_custody_attestation;
 /// `accord_holder` records + the entrenched-`family` 2-of-3 genesis, round-tripped
 /// through `threshold::verify_founder_quorum`.
 pub mod accord_genesis;
+/// HUMANITY_ACCORD live-quorum decimation-recovery objects (FSD-004 / CC §4.2.6)
+/// — Phase 1, step 1: the `AccordProposal` / `AccordParticipation` preimages with
+/// the adversarial-review CRITICAL bindings (vote + proposal digest + member +
+/// family + window in the signed bytes). The tally / fire / membership-change
+/// surfaces are step 2.
+pub mod accord_live_quorum;
 pub mod app_attest;
 pub mod attest_bundle;
 pub mod attest_heartbeat;


### PR DESCRIPTION
Begins the live-quorum decimation-recovery build (FSD-004 / CC §4.2.6), starting where the [adversarial review](FSD/FSD-004_ADVERSARIAL_REVIEW.md) found the soft underbelly: **the participation preimage**.

New `accord_live_quorum` module:
- `AccordProposal` (action + server nonce + window + `prior_family_digest` anchor) → `canonical_bytes` + `digest()`
- `AccordParticipation` (proof-of-life **bundled with** a `Vote`) → its own `canonical_bytes` + `verify(member, proposal)`

**CRITICAL review obligations baked in from the start, fail-closed:**
- **C1** (vote-flip / cross-proposal replay): the vote, the **full proposal digest** (never a bare nonce), the member seat, the family, and the window are ALL in the signed preimage. Tests prove flipping the recorded vote breaks the signature, and a participation for proposal A is rejected against B.
- **C2**: `window_until` in the signed bytes; `signed_at` explicitly advisory (the authoritative L-gate is server arrival — step 2).
- **C3**: the proposal binds `prior_family_digest` (the **standing** roster), so a participation is anchored to a decision over a specific standing roster, never the manipulable live set.
- **M3**: signature verified against the holder's **pinned** key; `member_id` self-attests its seat.
- **M5**: `family_key_id` bound in the preimage.
- Federation tier **RequireHybrid** — classical-only participation rejected.

Distinct domain prefixes (`ciris.accord_proposal.v1` / `ciris.accord_participation.v1`) keep these scope-isolated from invoke/lifecycle/family-envelope signatures (CC §9.2).

**Next (step 2):** `tally_live_quorum` + `verify_membership_change_by_live_quorum` + `verify_fire_by_live_quorum` — standing-roster anti-replay anchor, fire-floor-1, strict-majority-of-L, N_min + removal-continuity, the L_floor steward backstop, the equivocation gate, proposal coalescing, and the resumption-threshold asymmetry (per the review).

8 new tests; verify-core **747** lib green; clippy + doc clean. (No version bump — staged increment, like the TPM plugin stages.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)