### PR TITLE
ci(cache): align CIRISCache substrate key to the canonical cross-repo scheme (#153)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,14 +405,19 @@ jobs:
           targets: ${{ matrix.target }}
 
       # CIRISCache (CIRISVerify#126) — the **canonical cross-repo key** pinned in
-      # CIRISServer#99, suffixed with the matrix target (verify's build-native is
-      # a cross-compile matrix, so each target is a distinct build that must not
-      # collide on the shared os-arch host). For verify p=e=none (no
-      # ciris-persist / ciris-edge dep), v=ciris-verify-core's resolved version —
-      # so verify keeps its own compiled blob but shares the always-on ~/.cargo
-      # registry blob with the other repos. Derivation is byte-identical across
-      # repos (see #99) so the rustc/version segments line up.
-      - name: Compute CIRISCache key (canonical, CIRISServer#99)
+      # CIRISServer#99. The <PLAT> token is derived from the BUILD TARGET triple
+      # (not the runner host), so it is byte-identical to the per-platform key
+      # CIRISServer computes — and each of verify's 5 cross-matrix targets maps to
+      # a DISTINCT platform token, so there is no host collision and NO -<target>
+      # suffix is needed (the suffix is what defeated CIRISServer's cross-repo
+      # restore; CIRISVerify#153). For verify p=e=none (no ciris-persist /
+      # ciris-edge dep), v=ciris-verify-core's resolved version — so verify keeps
+      # its own compiled blob but shares the always-on ~/.cargo registry blob with
+      # the other repos. NB: coarse whole-dir target/ reuse across repos is
+      # fingerprint-sensitive (feature flags differ); the reliable cross-repo win
+      # is the cargo registry/git layer — key alignment is the prerequisite either
+      # way (#153 item 3).
+      - name: Compute CIRISCache key (canonical, CIRISServer#99 / #153)
         shell: bash
         run: |
           RUSTC=$(rustc -V | awk '{print $2}')
@@ -423,13 +428,19 @@ jobs:
           # `set -e`; flagged back there + on the persist/edge adopters.)
           ver() { { grep -A1 "name = \"$1\"" Cargo.lock | grep -m1 '^version' | sed -E 's/.*"([^"]+)".*/\1/'; } || true; }
           P=$(ver ciris-persist); E=$(ver ciris-edge); V=$(ver ciris-verify-core)
-          # `tr` for lowercasing, NOT bash's ${VAR,,} — GitHub macOS runners ship
-          # bash 3.2, where ${,,} is a "bad substitution" fatal error. (Second
-          # latent bug in the #99 snippet, also flagged upstream.)
-          OS=$(printf '%s' "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
-          ARCH=$(printf '%s' "$RUNNER_ARCH" | tr '[:upper:]' '[:lower:]')
-          KEY="ciris-substrate-v1-${OS}-${ARCH}-release-rustc${RUSTC}-p${P:-none}-e${E:-none}-v${V:-none}"
-          echo "CIRISCACHE_KEY=${KEY}-${{ matrix.target }}" >> "$GITHUB_ENV"
+          # Canonical <PLAT> token from the target triple — must match the table
+          # CIRISServer#99 uses for the equivalent platform (linux/macos use the
+          # x86_64/aarch64 arch spelling, NOT the runner's x64/arm64 token).
+          case "${{ matrix.target }}" in
+            x86_64-unknown-linux-gnu)  PLAT="linux-x86_64" ;;
+            aarch64-unknown-linux-gnu) PLAT="linux-aarch64" ;;
+            x86_64-apple-darwin)       PLAT="macos-x86_64" ;;
+            aarch64-apple-darwin)      PLAT="macos-aarch64" ;;
+            x86_64-pc-windows-msvc)    PLAT="windows-x64" ;;
+            *) PLAT="${{ matrix.target }}" ;;  # fail-safe: keep the triple for an unmapped target
+          esac
+          KEY="ciris-substrate-v1-${PLAT}-release-rustc${RUSTC}-p${P:-none}-e${E:-none}-v${V:-none}"
+          echo "CIRISCACHE_KEY=${KEY}" >> "$GITHUB_ENV"
       - uses: CIRISAI/CIRISCache/restore@v1
         continue-on-error: true
         with:


### PR DESCRIPTION
Closes #153.

## Problem
CIRISServer#99's cross-repo restore **never hit** this repo's saved substrate blob. Two key divergences:
1. We derived `<PLAT>` from the **runner host** (`RUNNER_OS`/`RUNNER_ARCH` → `linux-x64`, `macos-arm64`) instead of the canonical arch spelling CIRISServer uses (`linux-x86_64`, `macos-aarch64`).
2. We appended a `-${{ matrix.target }}` suffix.

→ different OCI tags → CIRISServer's `restore` missed our blob.

## Fix
Derive `<PLAT>` from the **build target triple** via a case map matching CIRISServer's table, and **drop the suffix**:

| target | `<PLAT>` |
|--------|---------|
| `x86_64-unknown-linux-gnu` | `linux-x86_64` |
| `aarch64-unknown-linux-gnu` | `linux-aarch64` |
| `x86_64-apple-darwin` | `macos-x86_64` |
| `aarch64-apple-darwin` | `macos-aarch64` |
| `x86_64-pc-windows-msvc` | `windows-x64` |

Verify's 5 cross-matrix targets each map to a **distinct** platform token, so there's no host collision — the suffix was only guarding host collisions that keying-by-target eliminates. The key is now byte-identical to CIRISServer's for the same `(platform, rustc, p/e/v)`.

## #153 checklist
- [x] **Item 1** — standardize the key (canonical `<PLAT>`, no suffix)
- [x] **Item 2** — save-on-main already wired (`save@v1` gated on `refs/heads/main`; workflow-level `permissions: packages: write`)
- [x] **Item 3** — caveat documented inline (coarse `target/` reuse is fingerprint-sensitive; the reliable cross-repo win is the cargo registry/git layer; key alignment is the prerequisite either way)

The changed `ci.yml` runs on this PR, so the new key compute is exercised before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)