### PR TITLE
ci: harden against recurring flakes + kill toolchain noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,11 +262,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          log-level: warn
-          command: check
-          arguments: ""
+      # Run cargo-deny RUNNER-NATIVE, not via EmbarkStudios/cargo-deny-action@v2.
+      # That action is a Docker container action whose *musl* rustup reads our
+      # rust-toolchain.toml and emits a spurious
+      #   error: override toolchain 'stable-x86_64-unknown-linux-musl' is not installed
+      # on every run (cosmetic, but permanent log noise), and — being containerized —
+      # it does NOT inherit this workflow's CARGO_NET_* crates.io-flake hardening.
+      # Native uses the installed gnu stable toolchain (zero override noise) and
+      # inherits the flake env for the advisory-DB fetch. (CIRISVerify CI hardening)
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-deny
+      - run: cargo deny check
 
   # ==========================================================================
   # Tests (using cargo-nextest for reliable parallel execution)
@@ -739,7 +745,11 @@ jobs:
   conformance-macos:
     name: Conformance (macOS)
     runs-on: macos-latest
-    timeout-minutes: 10
+    # macOS runners are slow; a COLD `cargo build --release` (cache miss) plus the
+    # conformance script routinely exceeded a 10-min job budget, which killed the
+    # test step mid-run (conclusion: cancelled — a false red, not a real failure).
+    # 25 min gives a cold build headroom. (CIRISVerify CI hardening)
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/post-release-verify.yml
+++ b/.github/workflows/post-release-verify.yml
@@ -115,7 +115,11 @@ jobs:
         # "install will succeed." Retry until success or 5 min.
         run: |
           set -eux
-          DEADLINE=$((SECONDS + 300))
+          # 15-min deadline (was 5): PyPI CDN propagation occasionally exceeds
+          # 5 min after upload (observed on v8.3.0, where the 300s window elapsed
+          # before pip could resolve a perfectly-good wheel — a false red on a
+          # post-release gate that isn't latency-critical). (CIRISVerify CI hardening)
+          DEADLINE=$((SECONDS + 900))
           VER="${{ steps.ver.outputs.version }}"
           # v4.11.0: PyPI's CDN edges propagate independently — two
           # back-to-back `--no-cache-dir` resolutions can hit different
@@ -179,7 +183,9 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
-          max_attempts: 2
+          # 3 attempts (was 2): one more backoff cycle for a late-propagating
+          # CDN edge, matching the widened propagation deadline above.
+          max_attempts: 3
           retry_wait_seconds: 30
           retry_on: timeout
           command: pip install "ciris-verify==${{ steps.ver.outputs.version }}"


### PR DESCRIPTION
Robust fixes for the three CI flake classes we've hit this cycle, each root-caused (not just re-run-until-green).

## 1. cargo-deny → runner-native (kills the toolchain noise)
`EmbarkStudios/cargo-deny-action@v2` is a **Docker container action** whose *musl* rustup reads our `rust-toolchain.toml` and prints on **every** run:
```
error: override toolchain 'stable-x86_64-unknown-linux-musl' is not installed
```
Cosmetic (cargo-deny still ran), but permanent log noise — and being containerized it **doesn't inherit** our `CARGO_NET_*` crates.io-flake hardening. Now runs native: `dtolnay/rust-toolchain@stable` + `taiki-e/install-action@cargo-deny` + `cargo deny check` → uses the installed gnu toolchain (zero override noise) and inherits the flake env for the advisory-DB fetch.

## 2. PyPI-propagation window (the v8.3.0 post-release false-red)
v8.3.0's post-release-verify failed because PyPI's CDN took >5 min to propagate a perfectly-good wheel. Widened: propagation deadline **300→900s**, install retries **2→3**. It's a post-release gate, not latency-critical.

## 3. macOS conformance timeout (the "cancelled" false-red)
`conformance-macos` had `timeout-minutes: 10`, but a **cold** macOS `cargo build --release` + the conformance script exceeds it → the step is **cancelled mid-run** (shows as failure, isn't one). Bumped to **25** for cold-build headroom.

## Already covered (confirmed, no change)
- crates.io HTTP/2 `unexpected eof` flake → `CARGO_NET_RETRY=10` + `CARGO_HTTP_MULTIPLEXING=false` + `CARGO_NET_TIMEOUT=60` in all 3 workflows (#148). cargo-deny going native now inherits these too.
- `taiki-e/install-action` bash-startup flake (partner-runner-images#169) → the action has **built-in retry**; the maintained `@<tool>` tags self-heal.

Net: fewer false reds, and the cargo-deny log is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)