### PR TITLE
ci: arch-partition build-ios cache key (fix ahash cross-arch cache poisoning)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -671,7 +671,16 @@ jobs:
           # v2.1.4+: exclude ~/.cargo/bin to prevent rustup-init shadow
           # poisoning. See ci.yml comment block above.
           cache-bin: false
-          key: ios-${{ matrix.target }}
+          # Partition the cache by runner arch. Swatinem only bakes CPU arch into
+          # the key for arm64 *Linux*; on macOS (macos-latest is now arm64;
+          # macos-13 was the last x86_64) a cross-arch or one-time-corrupted
+          # target/ restore surfaces as `ahash build-script-build: cannot execute
+          # binary file` (an exec-format error on a host build script). This
+          # build-ios lane cross-compiles (host-arch build scripts + iOS target
+          # artifacts share one target/ tree), so it's the sensitive one. Adding
+          # runner.arch evicts any wrong-arch/stale blob and keeps caches
+          # arch-distinct going forward. (CIRISVerify CI hardening)
+          key: ios-${{ matrix.target }}-${{ runner.arch }}
 
       # CIRISCache (CIRISVerify#126 / #155) — canonical cross-repo key for the
       # ios PLAT. <PLAT> = ios-<target> (matches the edge + persist convention)


### PR DESCRIPTION
## The flake
`build-ios` intermittently fails with:
```
error: failed to run custom build command for `ahash v0.8.12`
  …/build-script-build: cannot execute binary file
```
An **exec-format error** — the restored `target/` tree held a host build-script binary the runner couldn't execute.

## Root cause (researched)
[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) only bakes CPU arch into the cache key for **arm64 Linux**; on macOS it doesn't. `macos-latest` is now **arm64** (macos-13 was the last x86_64), so a cross-arch — or one-time-corrupted — `target/` restore isn't prevented. This lane **cross-compiles** (host-arch build scripts + iOS target artifacts share one `target/` tree), making it the sensitive one; a host build-script from the wrong/again-corrupt blob → `cannot execute binary file`.

## Fix
Add `runner.arch` to the cache key: `ios-<target>` → `ios-<target>-<arch>`. This **evicts** any wrong-arch/stale blob (one cold build) and keeps caches **arch-distinct** going forward — robust under both the cross-arch and one-time-corruption hypotheses.

## Scope
- ubuntu lanes are all `ubuntu-latest` (x86_64) → no arch ambiguity, unchanged.
- `conformance-macos` / `test` (macOS) build **host-consistently** (arm64 save/restore) → not affected.

CI-only change (no code/wheel), so no release tag.

Sources: [Swatinem/rust-cache releases](https://github.com/Swatinem/rust-cache/releases), [actions/runner#3256 (macos-latest→arm64)](https://github.com/actions/runner/issues/3256)

🤖 Generated with [Claude Code](https://claude.com/claude-code)