### PR TITLE
chore(deps): drop provably-unused deps — machete-verified (#164 + extras)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,29 +353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
-dependencies = [
- "aws-lc-sys",
- "untrusted 0.7.1",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,8 +560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -708,7 +683,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -718,7 +692,6 @@ dependencies = [
 name = "ciris-crypto"
 version = "8.5.0"
 dependencies = [
- "aws-lc-rs",
  "chacha20poly1305",
  "criterion",
  "ed25519-dalek",
@@ -731,10 +704,8 @@ dependencies = [
  "oqs",
  "p256",
  "pbkdf2",
- "pkcs8 0.11.0",
  "pretty_assertions",
  "proptest",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "ring",
  "serde",
@@ -793,14 +764,11 @@ name = "ciris-manifest-tool"
 version = "8.5.0"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
  "chrono",
- "ciris-crypto",
  "ciris-verify-core",
  "clap 4.6.1",
  "goblin",
  "hex",
- "serde",
  "serde_json",
  "sha2",
  "thiserror 1.0.69",
@@ -822,7 +790,6 @@ name = "ciris-verify-core"
 version = "8.5.0"
 dependencies = [
  "android_system_properties",
- "anyhow",
  "async-trait",
  "base64 0.21.7",
  "chacha20poly1305",
@@ -840,8 +807,6 @@ dependencies = [
  "libc",
  "pretty_assertions",
  "proptest",
- "prost",
- "prost-build",
  "qrcode",
  "rand 0.8.6",
  "rcgen",
@@ -882,14 +847,12 @@ dependencies = [
  "ctor",
  "dirs",
  "ed25519-dalek",
- "getrandom 0.2.17",
  "hex",
  "hkdf",
  "jni",
  "libc",
  "log",
  "oslog",
- "prost",
  "rand 0.8.6",
  "rcgen",
  "rustls 0.23.40",
@@ -1404,12 +1367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,12 +1578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,12 +1597,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -2455,16 +2400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2738,12 +2673,6 @@ dependencies = [
  "num-traits",
  "zeroize",
 ]
-
-[[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nix"
@@ -3087,16 +3016,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.14.0",
-]
-
-[[package]]
 name = "picky-asn1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3350,59 +3269,6 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
-]
-
-[[package]]
-name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
-dependencies = [
- "bytes",
- "heck 0.5.0",
- "itertools 0.12.1",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 2.0.117",
- "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
-dependencies = [
- "prost",
 ]
 
 [[package]]
@@ -3715,7 +3581,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -3883,7 +3749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -3894,7 +3760,7 @@ checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -3978,7 +3844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -4793,12 +4659,6 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,6 @@ futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-# Protobuf (Veilid-compatible)
-prost = "0.12"
-prost-types = "0.12"
-tonic = "0.10"
-tonic-build = "0.10"
-
 # Classical cryptography
 p256 = { version = "0.13", features = ["ecdsa", "pem"] }
 ed25519-dalek = { version = "2.1", features = ["rand_core"] }

--- a/src/ciris-build-tool/Cargo.toml
+++ b/src/ciris-build-tool/Cargo.toml
@@ -52,7 +52,6 @@ chrono = { version = "0.4", features = ["serde", "clock"] }
 
 # Error handling
 anyhow.workspace = true
-thiserror.workspace = true
 
 # Logging
 tracing.workspace = true

--- a/src/ciris-crypto/Cargo.toml
+++ b/src/ciris-crypto/Cargo.toml
@@ -17,9 +17,8 @@ default = ["ecdsa-p256", "ed25519", "secp256k1", "random"]
 ecdsa-p256 = ["p256"]
 ed25519 = ["ed25519-dalek"]
 secp256k1 = ["k256"]
-# PQC feature - enable one of these
-pqc-ml-dsa = ["ml-dsa", "rand_chacha", "dep:pkcs8", "dep:zeroize"]
-pqc-aws-lc = ["aws-lc-rs"]
+# PQC feature (ML-DSA-65 / FIPS 204)
+pqc-ml-dsa = ["ml-dsa", "dep:zeroize"]
 
 # v2.0+ — federation symmetric / KDF / MAC / RNG primitives. Each is
 # its own feature so consumers (CIRISPersist#19's federated SecretsService,
@@ -73,7 +72,6 @@ thiserror.workspace = true
 serde = { workspace = true, features = ["derive"] }
 sha2.workspace = true
 rand_core.workspace = true
-rand_chacha = { version = "0.3", optional = true }
 subtle = "2.6"
 
 # Classical cryptography
@@ -106,15 +104,9 @@ ml-dsa = { version = "=0.1.1", optional = true, features = ["zeroize"] }
 # `SigningKey.seed` is also `ZeroizeOnDrop` (CIRISVerify#87 closed).
 zeroize = { version = "1", optional = true }
 
-# v6.x (CIRISVerify#87): ml-dsa 0.1.1 (stable line) builds against the
-# stable `pkcs8 0.11.0`. The rc.8-era `=0.11.0-rc.11` pin existed only to
-# dodge an rc.8↔stable `Error::KeyMalformed` unit-vs-function mismatch in
-# ml-dsa's own source; ml-dsa 0.1.1 uses the stable variant correctly, so
-# the workaround is retired and we pin the stable `=0.11.0` to keep the
-# federation crypto authority pattern (one place owns every crypto-
-# transitive). Tested: `rm -f Cargo.lock && cargo build` fresh-resolves.
-pkcs8 = { version = "=0.11.0", optional = true, default-features = false }
-aws-lc-rs = { version = "1.5", features = ["unstable"], optional = true }
+# NB (CIRISVerify#164): the direct `pkcs8 =0.11.0` pin + the aspirational
+# `aws-lc-rs`/`pqc-aws-lc` backend were dropped as provably-unused — ml-dsa 0.1.1
+# already forces `pkcs8 0.11.0` transitively, and no source referenced aws_lc_rs.
 
 # v2.0+ — symmetric / MAC primitives. PBKDF2 is a separate dep from hkdf
 # because RustCrypto split them across crates.

--- a/src/ciris-manifest-tool/Cargo.toml
+++ b/src/ciris-manifest-tool/Cargo.toml
@@ -19,21 +19,15 @@ goblin.workspace = true
 # CLI
 clap.workspace = true
 
-# Cryptography
-ciris-crypto.workspace = true
 
 # Core types
 ciris-verify-core.workspace = true
 
-# Serialization
-serde.workspace = true
 serde_json.workspace = true
 
 # Hashing
 sha2.workspace = true
 
-# Encoding
-base64.workspace = true
 hex.workspace = true
 
 # Time

--- a/src/ciris-verify-core/Cargo.toml
+++ b/src/ciris-verify-core/Cargo.toml
@@ -61,11 +61,9 @@ serde_json.workspace = true
 # crate's `ryu-js` backend rather than being hand-rolled. Behavior is
 # locked by RFC 8785 Appendix B KAT vectors in `jcs::tests`.
 serde_jcs = "0.2"
-prost.workspace = true
 
 # Error handling
 thiserror.workspace = true
-anyhow.workspace = true
 
 # Logging
 tracing.workspace = true
@@ -188,9 +186,6 @@ windows-sys = { version = "0.52", features = [
     "Win32_System_Threading",
     "Win32_System_Diagnostics_Debug",
 ] }
-
-[build-dependencies]
-prost-build = "0.12"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/src/ciris-verify-ffi/Cargo.toml
+++ b/src/ciris-verify-ffi/Cargo.toml
@@ -44,7 +44,6 @@ ciris-keyring.workspace = true
 # (X25519 + ML-KEM-768) exposed on the wheel via `wheel_self_enc` — also always-on.
 ciris-crypto = { workspace = true, features = ["scope-privacy", "self-enc"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-prost.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 serde = { workspace = true, features = ["derive"] }
@@ -52,7 +51,6 @@ serde_json.workspace = true
 base64.workspace = true
 libc = "0.2"
 hex.workspace = true
-getrandom = "0.2"
 ed25519-dalek = { workspace = true }
 # v6 drops the windows-sys 0.48 → windows-targets 0.48.5 chain that fails to
 # link on the Tier-3 x86_64-win7-windows-msvc target (CIRISVerify#67).


### PR DESCRIPTION
Closes #164. Removes dead dependencies confirmed unused by **cargo machete + source grep** (zero refs each). **13 crates dropped from Cargo.lock** (583→570), no source change.

## Removed
| Crate | Dead deps |
|-------|-----------|
| verify-core | `prost` (+ `prost-build` build-dep), `anyhow` |
| ffi | `prost`, `getrandom 0.2` |
| crypto | `rand_chacha`, `pkcs8 =0.11.0` pin (ml-dsa forces it transitively), `aws-lc-rs` + the aspirational `pqc-aws-lc` feature |
| **manifest-tool** | `base64`, `ciris-crypto`, `serde` *(beyond #164 — machete)* |
| **build-tool** | `thiserror` *(beyond #164 — machete)* |
| workspace | the whole dead **Protobuf** block — `prost`/`prost-types`/`tonic`/`tonic-build` were declared but referenced by nothing |

Net: the entire prost/tonic build tree is gone (`prost`, `prost-build`, `prost-derive`, `prost-types`, `tonic`, `aws-lc-rs` — all 0 in the lock).

## Verified
- **cargo machete now reports clean** (0 unused).
- 775 verify-core + 75 ffi lib tests pass; clippy `-D warnings` + fmt clean; `pqc-ml-dsa` still builds.
- `protocol/ciris_verify.proto` **kept** — it was never compiled (build.rs only sets `TARGET`); it's the public API contract, now doc-only.

## Not in this PR
- **#165** (`hickory-resolver` 0.24→0.25, the biggest single de-dup) is a real `dns.rs` API migration + needs DoH-path testing (operator-flagged medium risk) — kept as a separate focused effort.
- **No version bump** — Cargo.toml/lock only, no API/behavior change; rides the next release (say the word for a patch release if you want the leaner wheel published now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)