### PR TITLE
fix(v8.10.1): manifest-sign outbox id includes target (multi-target collision)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-build-tool"
-version = "8.10.0"
+version = "8.10.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-crypto"
-version = "8.10.0"
+version = "8.10.1"
 dependencies = [
  "chacha20poly1305",
  "criterion",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-keyring"
-version = "8.10.0"
+version = "8.10.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-manifest-tool"
-version = "8.10.0"
+version = "8.10.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-tpm-plugin"
-version = "8.10.0"
+version = "8.10.1"
 dependencies = [
  "sha2",
  "tracing",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-verify-core"
-version = "8.10.0"
+version = "8.10.1"
 dependencies = [
  "android_system_properties",
  "async-trait",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "ciris-verify-ffi"
-version = "8.10.0"
+version = "8.10.1"
 dependencies = [
  "aes-gcm",
  "android_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "8.10.0"
+version = "8.10.1"
 edition = "2021"
 rust-version = "1.86"
 license = "AGPL-3.0-or-later"

--- a/bindings/python/ciris_verify/__init__.py
+++ b/bindings/python/ciris_verify/__init__.py
@@ -155,7 +155,7 @@ def get_library_version() -> str:
     return __version__
 
 
-__version__ = "8.10.0"
+__version__ = "8.10.1"
 __all__ = [
     "CIRISVerify",
     "MockCIRISVerify",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciris-verify"
-version = "8.10.0"
+version = "8.10.1"
 description = "Python bindings for CIRISVerify hardware-rooted license verification"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/src/ciris-verify-core/src/bin/ciris_verify.rs
+++ b/src/ciris-verify-core/src/bin/ciris_verify.rs
@@ -3546,7 +3546,10 @@ async fn run_manifest_sign(a: ManifestSignArgs) {
         },
     };
 
-    let path = match obj.write_to_outbox(&format!("manifest-{}", a.build_id)) {
+    // Include the target so a multi-target build (CI signs each target under one
+    // --build-id v<VERSION>) doesn't overwrite prior contributions — write_to_outbox
+    // is fs::write (overwrite). Matches the build-tool producer's {build_id}-{target}.
+    let path = match obj.write_to_outbox(&format!("manifest-{}-{}", a.build_id, a.target)) {
         Ok(p) => p,
         Err(e) => {
             eprintln!("❌ write CEG outbox: {e}");


### PR DESCRIPTION
**Codex review catch on #177 (P2).** The `manifest sign` outbox filename was `manifest-<build_id>.json`, but the release workflow signs each target inside a per-target loop under one `--build-id v<VERSION>`. Since `write_to_outbox` is `std::fs::write` (overwrite), every later target **clobbered** the prior contribution — dropping all but one target's manifest before CIRISServer could relay them.

**Fix:** `manifest-<build_id>-<target>` — matching the existing build-tool producer's `{build_id}-{target}` convention. Target triples (`x86_64-unknown-linux-gnu`) are filename-safe.

Patch bump 8.10.1. Builds (+pkcs11), fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)