### PR TITLE
ci: pin rustc to exact 1.97.0 — align the CIRISCache substrate key across the centipede (#179)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           components: rustfmt
 
@@ -165,7 +165,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           components: clippy
 
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
 
       - name: Repair toolchain if rustup-init shadow (cache-poison heal)
         # v2.1.2 detected; v2.1.3 moved after cache restore; v2.1.4 active heal.
@@ -270,7 +270,7 @@ jobs:
       # it does NOT inherit this workflow's CARGO_NET_* crates.io-flake hardening.
       # Native uses the installed gnu stable toolchain (zero override noise) and
       # inherits the flake env for the advisory-DB fetch. (CIRISVerify CI hardening)
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
       - uses: taiki-e/install-action@cargo-deny
       - run: cargo deny check
 
@@ -287,7 +287,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
 
       # CIRISCache (CIRISVerify#126) — GHCR-backed cross-repo Rust cache,
       # replacing Swatinem/rust-cache (unlimited GHCR storage, survives the
@@ -353,7 +353,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
       - uses: Swatinem/rust-cache@v2
         continue-on-error: true
         with:
@@ -406,7 +406,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
 
@@ -536,7 +536,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
 
@@ -657,7 +657,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
 
@@ -761,7 +761,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
 
       - uses: Swatinem/rust-cache@v2
         # CI hardening (v2.1.1+): cache restore is a speedup, not a
@@ -813,7 +813,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
 
       - uses: Swatinem/rust-cache@v2
         # CI hardening (v2.1.1+): cache restore is a speedup, not a
@@ -871,7 +871,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
 
       - uses: Swatinem/rust-cache@v2
         # CI hardening (v2.1.1+): cache restore is a speedup, not a
@@ -959,7 +959,7 @@ jobs:
     continue-on-error: true  # Don't block CI on coverage
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           components: llvm-tools-preview
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Default (stable) toolchain — all targets EXCEPT the Win7 build-std lane.
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         if: ${{ matrix.toolchain != 'nightly' }}
         with:
           targets: ${{ matrix.target }}
@@ -266,7 +266,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: aarch64-unknown-linux-musl
 
@@ -369,7 +369,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
 
@@ -464,7 +464,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
 
@@ -625,7 +625,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
 
       - uses: Swatinem/rust-cache@v2
         # CI hardening (v2.1.1+): cache restore failures degrade to
@@ -691,7 +691,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
 
       - uses: Swatinem/rust-cache@v2
         # CI hardening (v2.1.1+): cache restore failures degrade to
@@ -775,7 +775,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,9 +1,18 @@
 # Common toolchain pin across the four Rust-compiling CIRIS repos (server /
-# persist / edge / verify) — the rustc version is part of the sccache cache key,
-# so a drift = zero cross-repo cache hits (CIRISVerify#126 / CIRISServer#99).
-# Matches CIRISServer's pin. Stable for all targets except the Win7 Tier-3
-# build-std lane, which the release workflow pins to nightly + rust-src per-job
-# (CIRISVerify#67 pattern); MSRV is enforced separately in CI.
+# persist / edge / verify) — the rustc version is part of the CIRISCache substrate
+# key (`…-rustc<VER>-…`), so any drift = zero cross-repo cache hits
+# (CIRISVerify#126 / CIRISServer#99).
+#
+# EXACT-PINNED (CIRISVerify#179): a floating `channel = "stable"` is NOT a pin —
+# each repo's runner resolves whatever stable GitHub's image ships that day, so
+# the four repos silently drift apart on every runner-image rustc bump. That is
+# exactly what cold-built CIRISServer's windows wheel: verify's blob was keyed
+# `rustc1.96.1` while the server's windows runner had `rustc1.97.0` (GitHub bumped
+# windows-latest stable 1.96→1.97 on 2026-07-07) → substrate MISS. Pinning the
+# EXACT version makes the `-rustc<VER>` key segment deterministic and matched
+# across the centipede. **All four repos must carry the same exact channel; bump
+# in lockstep.** The Win7 Tier-3 build-std lane still overrides to nightly + rust-src
+# per-job (CIRISVerify#67); MSRV (1.86) is enforced separately in CI.
 [toolchain]
-channel = "stable"
+channel = "1.97.0"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -11,7 +11,13 @@
 # windows-latest stable 1.96→1.97 on 2026-07-07) → substrate MISS. Pinning the
 # EXACT version makes the `-rustc<VER>` key segment deterministic and matched
 # across the centipede. **All four repos must carry the same exact channel; bump
-# in lockstep.** The Win7 Tier-3 build-std lane still overrides to nightly + rust-src
+# in lockstep.** dtolnay/rust-toolchain does NOT read this file — it installs the
+# ref'd toolchain and adds cross-targets to IT — so the CI workflow steps pin the
+# SAME exact version (`dtolnay/rust-toolchain@1.97.0` in ci.yml/release.yml). If the
+# action ref and this channel diverge, cargo runs this channel while the target was
+# added to the action's → `E0463: can't find crate for core` on cross builds. Bump
+# BOTH (this file + every `@1.97.0` workflow ref) together.
+# The Win7 Tier-3 build-std lane still overrides to nightly + rust-src
 # per-job (CIRISVerify#67); MSRV (1.86) is enforced separately in CI.
 [toolchain]
 channel = "1.97.0"

--- a/src/ciris-verify-core/src/bin/ciris_verify.rs
+++ b/src/ciris-verify-core/src/bin/ciris_verify.rs
@@ -987,8 +987,8 @@ async fn run_self_check(registry_url: &str, project: &str, json: bool) {
         println!("Binary Information:");
         println!("  Target: {}", target);
         println!("  Version: {}", VERSION);
-        println!("  SHA-256: {}", &self_hash[..16].to_uppercase());
-        println!("           {}...", &self_hash[16..32].to_uppercase());
+        println!("  SHA-256: {}", self_hash[..16].to_uppercase());
+        println!("           {}...", self_hash[16..32].to_uppercase());
         println!();
     }
 


### PR DESCRIPTION
## Root cause (#179)
CIRISServer's windows wheel builds fully cold because the substrate cache MISSES — not a missing save (verify publishes the windows-x64 blob fine), but a **rustc-key mismatch**: verify's blob was keyed `rustc1.96.1`, the server's windows runner has `rustc1.97.0` (GitHub bumped `windows-latest` stable 1.96→1.97 on 2026-07-07). The substrate key includes `-rustc<VER>`, and both repos float `channel = "stable"`, so they drift apart on every runner-image bump.

## Fix
Pin the **exact** version: `channel = "stable"` → `channel = "1.97.0"` (matches the server's current runner, verified `rustc 1.97.0 (2d8144b78 2026-07-07)`). The `-rustc` key segment is now deterministic + matched. **All four repos must carry the same exact channel and bump in lockstep** (downstream comments incoming).

Also fixes 2 new `redundant-reference in println!` lints that 1.97's clippy flags under `-D warnings`.

Verified: rustup auto-installs 1.97.0 from the toolchain file; workspace builds + clippy `-D warnings` clean on 1.97.0. No version bump (build-config only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)